### PR TITLE
security: role-based route guard, shared unsubscribable, auth cleanup

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,6 +5,7 @@ import {RegisterComponent} from './register/register.component';
 import {TransactionsComponent} from "./transactions/transactions.component";
 import {AuthGuard} from "./guards/auth.guard";
 import {NoAuthGuard} from "./guards/no-auth.guard";
+import {RoleGuard} from "./guards/role.guard";
 import { ProductListComponent } from './product-list/product-list.component';
 import { BrandListComponent } from './brand-list/brand-list.component';
 import { UserListComponent } from './user-list/user-list.component';
@@ -24,6 +25,9 @@ import { CreateProductComponent } from './create-product/create-product.componen
 import { EditProductComponent } from './edit-product/edit-product.component';
 import { TransactionLedgerComponent } from './transaction-ledger/transaction-ledger.component';
 
+const ADMIN = ['SuperUser'];
+const STAFF = ['SuperUser', 'SalesExecutive'];
+
 export const routes: Routes = [
     {path: 'login', component: LoginComponent, canActivate: [NoAuthGuard]},
     {path: 'register', component: RegisterComponent},
@@ -31,31 +35,27 @@ export const routes: Routes = [
     {
         path: '', component: LayoutComponent, canActivate: [AuthGuard],
         children: [
-            {path: '', component: DashboardComponent, canActivate: [AuthGuard]},
-            {path: 'dashboard', component: DashboardComponent, canActivate: [AuthGuard]},
-            {path: 'batch-list', component: BatchListComponent, canActivate: [AuthGuard]},
-            {path: 'create-batch', component:CreateBatchComponent, canActivate: [AuthGuard]},
-            {path: 'transactions', component: TransactionsComponent, canActivate: [AuthGuard]},
-            {path: 'product-list', component: ProductListComponent, canActivate: [AuthGuard]},
-            {path: 'brand-list', component: BrandListComponent, canActivate: [AuthGuard]},
-            {path: 'user-list', component: UserListComponent, canActivate: [AuthGuard]},
-            {path: 'unverified-users', component: UnverifiedUsersComponent, canActivate: [AuthGuard]},
-            {path: 'product-offers', component: ProductOffersComponent, canActivate: [AuthGuard]},
-            {path: 'reward-schemes', component: RewardSchemesComponent, canActivate: [AuthGuard]},
-            {path: 'payouts', component: PayoutsComponent, canActivate: [AuthGuard]},
-            {path: 'product-catalog', component: ProductCatlogComponent, canActivate:[AuthGuard]},
-            {path: 'order-list', component: OrderListComponent, canActivate:[AuthGuard]},
-            {path: 'piechart-dashboard', component:PiechartdashboardComponent, canActivate:[AuthGuard]},
-            {path: 'product-data-list', component:ProductDataListComponent, canActivate:[AuthGuard]},
-            {path: 'create-product', component:CreateProductComponent, canActivate:[AuthGuard]},
-            {path: 'edit-product', component:EditProductComponent, canActivate:[AuthGuard]},
-            {path: 'transaction-ledger', component:TransactionLedgerComponent, canActivate:[AuthGuard]},
-            
-            
+            {path: '', component: DashboardComponent},
+            {path: 'dashboard', component: DashboardComponent},
+            {path: 'batch-list', component: BatchListComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
+            {path: 'create-batch', component: CreateBatchComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
+            {path: 'transactions', component: TransactionsComponent, canActivate: [RoleGuard], data: { roles: STAFF }},
+            {path: 'product-list', component: ProductListComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
+            {path: 'brand-list', component: BrandListComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
+            {path: 'user-list', component: UserListComponent, canActivate: [RoleGuard], data: { roles: STAFF }},
+            {path: 'unverified-users', component: UnverifiedUsersComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
+            {path: 'product-offers', component: ProductOffersComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
+            {path: 'reward-schemes', component: RewardSchemesComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
+            {path: 'payouts', component: PayoutsComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
+            {path: 'product-catalog', component: ProductCatlogComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
+            {path: 'order-list', component: OrderListComponent, canActivate: [RoleGuard], data: { roles: STAFF }},
+            {path: 'piechart-dashboard', component: PiechartdashboardComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
+            {path: 'product-data-list', component: ProductDataListComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
+            {path: 'create-product', component: CreateProductComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
+            {path: 'edit-product', component: EditProductComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
+            {path: 'transaction-ledger', component: TransactionLedgerComponent},
         ]
 
     },
-  { path: '**', redirectTo: 'login' } 
-                              
-
+  { path: '**', redirectTo: 'login' }
 ];

--- a/src/app/batch-list/batch-list.component.ts
+++ b/src/app/batch-list/batch-list.component.ts
@@ -9,6 +9,8 @@ import { NgSelectComponent } from '@ng-select/ng-select';
 import Swal from "sweetalert2";
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap';
 import * as XLSX from 'xlsx';
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 
 @Component({
@@ -18,7 +20,7 @@ import * as XLSX from 'xlsx';
   templateUrl: './batch-list.component.html',
   styleUrl: './batch-list.component.css'
 })
-export class BatchListComponent {
+export class BatchListComponent extends Unsubscribable {
 branches: any[] = [];
 currentPage = 1;
 totalBranches = 0;
@@ -43,12 +45,13 @@ limitOptions = [10, 20, 50, 100];  // Available page size options
                 private router: Router,
                 private ApiUrls: ApiUrlsService,
                 private apiRequest: ApiRequestService) {
+        super();
     }
 
   ngOnInit(): void {
     this.loadBranches();
-    this.apiRequest.getAll(this.ApiUrls.getAllBrands).subscribe((response: any) => {
-        this.brands = response; 
+    this.apiRequest.getAll(this.ApiUrls.getAllBrands).pipe(takeUntil(this.destroy$)).subscribe((response: any) => {
+        this.brands = response;
     });
 }
 
@@ -56,7 +59,7 @@ limitOptions = [10, 20, 50, 100];  // Available page size options
 
     // Method to load branches with pagination
   loadBranches(page: number = this.currentPage, limit: number = this.limit): void {
-    this.apiRequest.post(this.ApiUrls.getBatches, { page, limit, searchQuery: this.searchQuery }).subscribe((response: any) => {
+    this.apiRequest.post(this.ApiUrls.getBatches, { page, limit, searchQuery: this.searchQuery }).pipe(takeUntil(this.destroy$)).subscribe((response: any) => {
       this.branches = response.branches;
       this.totalBranches = response.total; 
     }, (error) => {
@@ -75,7 +78,7 @@ limitOptions = [10, 20, 50, 100];  // Available page size options
 
       onSearch(): void {
         if (this.searchQuery.trim() !== '') {
-          this.apiRequest.searchBranch(this.ApiUrls.searchBranch, this.searchQuery).subscribe(
+          this.apiRequest.searchBranch(this.ApiUrls.searchBranch, this.searchQuery).pipe(takeUntil(this.destroy$)).subscribe(
             (response) => {
               this.branches = [response];
               this.totalBranches = 1;
@@ -137,7 +140,7 @@ limitOptions = [10, 20, 50, 100];  // Available page size options
         }).then((result) => {
             if (result.isConfirmed) {
                 // Proceed with updating the batch
-                this.apiRequest.update(this.ApiUrls.updateBatch + this.selectedBranch._id, this.selectedBranch).subscribe(
+                this.apiRequest.update(this.ApiUrls.updateBatch + this.selectedBranch._id, this.selectedBranch).pipe(takeUntil(this.destroy$)).subscribe(
                     (response) => {
                         this.loadBranches(); // Reload the branches list
                         this.closeUpdateModal(); // Close the modal
@@ -158,7 +161,7 @@ limitOptions = [10, 20, 50, 100];  // Available page size options
     
 
     onDelete(id: string): void {
-        this.apiRequest.getCouponSeries(this.ApiUrls.branchDeletedAffectedCouponsCount + id).subscribe((response) => {
+        this.apiRequest.getCouponSeries(this.ApiUrls.branchDeletedAffectedCouponsCount + id).pipe(takeUntil(this.destroy$)).subscribe((response) => {
             console.log(response)
             let text = response.message;
             Swal.fire({
@@ -170,7 +173,7 @@ limitOptions = [10, 20, 50, 100];  // Available page size options
                 cancelButtonText: 'No, keep it'
             }).then((result) => {
                 if (result.isConfirmed) {
-                    this.apiRequest.delete(this.ApiUrls.deleteBatch + id).subscribe((response) => {
+                    this.apiRequest.delete(this.ApiUrls.deleteBatch + id).pipe(takeUntil(this.destroy$)).subscribe((response) => {
                         this.loadBranches();
                     }, (error) => {
                         console.error('Error deleting branch:', error);
@@ -188,7 +191,7 @@ limitOptions = [10, 20, 50, 100];  // Available page size options
     }
    
    getProducts(): void {
-    this.apiRequest.getAll(this.ApiUrls.getAllProducts).subscribe((response: any) => {
+    this.apiRequest.getAll(this.ApiUrls.getAllProducts).pipe(takeUntil(this.destroy$)).subscribe((response: any) => {
         this.productData = response;
     });
 }

--- a/src/app/brand-list/brand-list.component.ts
+++ b/src/app/brand-list/brand-list.component.ts
@@ -5,6 +5,8 @@ import { CommonModule } from '@angular/common';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import Swal from 'sweetalert2'; 
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap';
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-brand-list',
@@ -13,7 +15,7 @@ import { NgbPagination } from '@ng-bootstrap/ng-bootstrap';
   templateUrl: './brand-list.component.html',
   styleUrls: ['./brand-list.component.css']
 })
-export class BrandListComponent {
+export class BrandListComponent extends Unsubscribable {
  brands: any[] = [];
   searchQuery: string = '';
   currentBrand: any = { name: '' };
@@ -32,7 +34,7 @@ export class BrandListComponent {
   constructor(
     private apiRequestService: ApiRequestService,
     private modalService: NgbModal
-  ) { }
+  ) { super(); }
 
   @ViewChild('brandForm', { static: false }) brandForm!: NgForm;
 
@@ -42,7 +44,7 @@ export class BrandListComponent {
 
   loadBrands(): void {
     const data = { page: this.currentPage, limit: this.limit };
-    this.apiRequestService.getAllBrands(data).subscribe({
+    this.apiRequestService.getAllBrands(data).pipe(takeUntil(this.destroy$)).subscribe({
       next: (response: any) => {
         this.brands = response.brands;
         this.totalBrands = response.pagination.totalBrands;
@@ -61,7 +63,7 @@ export class BrandListComponent {
     }
 
     this.isSearching = true;
-    this.apiRequestService.searchBrandsByName(this.searchQuery, this.currentPage, this.limit).subscribe({
+    this.apiRequestService.searchBrandsByName(this.searchQuery, this.currentPage, this.limit).pipe(takeUntil(this.destroy$)).subscribe({
       next: (response: any) => {
         if (response && response.data && response.data.length > 0) {
           this.brands = response.data;
@@ -118,7 +120,7 @@ export class BrandListComponent {
           ? this.apiRequestService.updateBrand(this.currentBrand._id, this.currentBrand)
           : this.apiRequestService.createBrand(this.currentBrand);
 
-        saveRequest.subscribe({
+        saveRequest.pipe(takeUntil(this.destroy$)).subscribe({
           next: () => {
             this.loadBrands();
             this.showSuccess(this.currentBrand._id ? 'Brand updated successfully!' : 'Brand added successfully!');
@@ -144,7 +146,7 @@ export class BrandListComponent {
       cancelButtonText: 'No, keep it'
     }).then((result) => {
       if (result.isConfirmed) {
-        this.apiRequestService.deleteBrand(id).subscribe(() => {
+        this.apiRequestService.deleteBrand(id).pipe(takeUntil(this.destroy$)).subscribe(() => {
           this.loadBrands();
           Swal.fire('Deleted!', 'Your brand has been deleted.', 'success');
         }, () => {

--- a/src/app/create-batch/create-batch.component.ts
+++ b/src/app/create-batch/create-batch.component.ts
@@ -7,6 +7,8 @@ import {ApiUrlsService} from "../services/api-urls.service";
 import {ApiRequestService} from "../services/api-request.service";
 import {Router} from "@angular/router";
 import Swal from "sweetalert2";
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-create-batch',
@@ -15,7 +17,7 @@ import Swal from "sweetalert2";
   templateUrl: './create-batch.component.html',
   styleUrl: './create-batch.component.css'
 })
-export class CreateBatchComponent {
+export class CreateBatchComponent extends Unsubscribable {
     branchName: string = '';
      ProductName: any = null;  
   Brand: any = null; 
@@ -38,11 +40,12 @@ export class CreateBatchComponent {
 
 
     constructor(private ApiUrls: ApiUrlsService, private ApiRequest: ApiRequestService, private router: Router,) {
+        super();
     }
 
     ngOnInit() {
     // Fetch all brands initially
-    this.ApiRequest.getAll(this.ApiUrls.getAllBrands).subscribe(
+    this.ApiRequest.getAll(this.ApiUrls.getAllBrands).pipe(takeUntil(this.destroy$)).subscribe(
       (brands: any[]) => {
         this.brandData = brands;
       },
@@ -53,7 +56,7 @@ export class CreateBatchComponent {
     );
 
     // Fetch coupon series as before
-    this.ApiRequest.getCouponSeries(this.ApiUrls.couponSeries).subscribe(
+    this.ApiRequest.getCouponSeries(this.ApiUrls.couponSeries).pipe(takeUntil(this.destroy$)).subscribe(
       (data: any[]) => {
         this.couponSeriesList = data.map(series => series.name);
       },
@@ -68,7 +71,7 @@ export class CreateBatchComponent {
  onBrandChange() {
   console.log('Selected Brand ID:', this.Brand);
   if (this.Brand) {
-   this.ApiRequest.getAll(this.ApiUrls.getAllProductsForSelect + this.Brand).subscribe(
+   this.ApiRequest.getAll(this.ApiUrls.getAllProductsForSelect + this.Brand).pipe(takeUntil(this.destroy$)).subscribe(
   (response: any[]) => {
     this.products = response;
   },
@@ -186,7 +189,7 @@ export class CreateBatchComponent {
             cancelButtonText: 'No, cancel'
         }).then((result) => {
             if (result.isConfirmed) {
-                this.ApiRequest.create(this.ApiUrls.createBatch, newBranch).subscribe(
+                this.ApiRequest.create(this.ApiUrls.createBatch, newBranch).pipe(takeUntil(this.destroy$)).subscribe(
                     (response: any) => {
                         console.log('Branch created successfully:', response.message);
                         this.errorEmptyStr = '';

--- a/src/app/create-product/create-product.component.ts
+++ b/src/app/create-product/create-product.component.ts
@@ -8,6 +8,8 @@ import { CommonModule, DatePipe } from '@angular/common';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { AuthService } from '../services/auth.service';
 import { Router } from '@angular/router';
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-create-product',
@@ -17,7 +19,7 @@ import { Router } from '@angular/router';
   templateUrl: './create-product.component.html',
   styleUrl: './create-product.component.css'
 })
-export class CreateProductComponent {
+export class CreateProductComponent extends Unsubscribable {
 
   @ViewChild('productCatlogForm') productCatlogForm!: NgForm;
   @ViewChild('fileInput') fileInput: any;
@@ -53,6 +55,7 @@ export class CreateProductComponent {
     private router: Router,
     private authService: AuthService
   ) {
+    super();
     this.currentUser = this.authService.currentUserValue;
   }
 
@@ -62,7 +65,7 @@ export class CreateProductComponent {
   }
 
   loadFocusDropdowns() {
-    this.apiRequestService.getFocusProducts().subscribe(
+    this.apiRequestService.getFocusProducts().pipe(takeUntil(this.destroy$)).subscribe(
       (res: any) => {
 
         if (!res.success) {
@@ -244,6 +247,7 @@ export class CreateProductComponent {
 
     this.apiRequestService
       .createWithImage(this.apiUrls.createProductCatlog, formData)
+      .pipe(takeUntil(this.destroy$))
       .subscribe(
         () => {
           Swal.fire('Success', 'Product catalog added successfully', 'success');

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,14 +1,13 @@
 import { Component, OnInit } from '@angular/core';
-import { Router, NavigationEnd } from '@angular/router';
+import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 
-import { filter } from 'rxjs';
+import { takeUntil } from 'rxjs';
 import {AuthService} from "../services/auth.service";
 import {ApiRequestService} from "../services/api-request.service";
 import {ApiUrlsService} from "../services/api-urls.service";
-
-declare var jQuery: any;
+import { Unsubscribable } from '../shared/unsubscribable';
 
 @Component({
   selector: 'app-dashboard',
@@ -17,26 +16,28 @@ declare var jQuery: any;
   templateUrl: './dashboard.component.html',
   styleUrls: ['./dashboard.component.css']
 })
-export class DashboardComponent implements OnInit {
-  isSidebarCollapsed: boolean = false;  // Sidebar starts collapsed by default
+export class DashboardComponent extends Unsubscribable implements OnInit {
+  isSidebarCollapsed: boolean = false;
   active: boolean = false;
   currentUser: any = {};
   userDashboardData: any;
 
   constructor(private router: Router, private AuthService: AuthService, private apiService: ApiRequestService, private apiUrls: ApiUrlsService) {
+    super();
     this.currentUser = this.AuthService.currentUserValue;
   }
-  
+
   ngOnInit() {
-    this.userDashboard()
+    this.userDashboard();
   }
 
   userDashboard(): void {
-    // debugger
-    this.apiService.create(this.apiUrls.userDashboard, {id: this.currentUser.id, accountType: this.currentUser.accountType}).subscribe((response) => {
-      this.userDashboardData = response.data;
-    }, (error) => {
-      console.error('Error loading branches:', error);
-    });
+    this.apiService
+      .create(this.apiUrls.userDashboard, { id: this.currentUser.id, accountType: this.currentUser.accountType })
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(
+        (response) => { this.userDashboardData = response.data; },
+        (error) => { console.error('Failed to load user dashboard', error); }
+      );
   }
 }

--- a/src/app/edit-product/edit-product.component.ts
+++ b/src/app/edit-product/edit-product.component.ts
@@ -6,6 +6,8 @@ import { ApiUrlsService } from '../services/api-urls.service';
 import Swal from 'sweetalert2';
 import { CommonModule } from '@angular/common';
 import { NgSelectModule } from '@ng-select/ng-select';
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 
 @Component({
@@ -15,7 +17,7 @@ import { NgSelectModule } from '@ng-select/ng-select';
   templateUrl: './edit-product.component.html',
   styleUrl: './edit-product.component.css'
 })
-export class EditProductComponent {
+export class EditProductComponent extends Unsubscribable {
   @ViewChild('productCatlogForm') productCatlogForm!: NgForm;
 
   currentCatlog: any = {
@@ -43,6 +45,7 @@ export class EditProductComponent {
     private apiRequestService: ApiRequestService,
     public apiUrls: ApiUrlsService
   ) {
+    super();
     const nav = this.router.getCurrentNavigation();
     const navState = nav?.extras?.state;
 
@@ -74,7 +77,7 @@ export class EditProductComponent {
   }
 
   loadFocusProducts() {
-    this.apiRequestService.getFocusProducts().subscribe(
+    this.apiRequestService.getFocusProducts().pipe(takeUntil(this.destroy$)).subscribe(
       (res: any) => {
 
         if (!res || res.success === false) {
@@ -377,6 +380,7 @@ export class EditProductComponent {
 
       this.apiRequestService
         .updateWithImage(this.apiUrls.updateProductCatlog + this.currentCatlog._id, formData)
+        .pipe(takeUntil(this.destroy$))
         .subscribe(
           () => {
             Swal.fire('Success', 'Product catalog updated successfully', 'success');

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -13,19 +13,18 @@ export class AuthGuard implements CanActivate {
   }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    const currentAccessToken = this.authService.currentUserValue;
+    const authenticated = this.authService.isAuthenticated();
 
-    // If token exists and user tries to access login, redirect to dashboard
-    if (state.url === '/login' && currentAccessToken && this.authService.isAuthenticated()) {
+    // Authenticated user hitting /login: redirect home.
+    if (state.url === '/login' && authenticated) {
       this.router.navigate(['/']);
       return false;
     }
 
-    if (currentAccessToken && this.authService.isAuthenticated()) {
-      return true; // Token exists, allow access to protected routes
+    if (authenticated) {
+      return true;
     }
 
-    // Redirect to login if no valid token
     this.router.navigate(['/login'], { queryParams: { returnUrl: state.url } });
     return false;
   }

--- a/src/app/guards/role.guard.ts
+++ b/src/app/guards/role.guard.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+// Backend remains the source of truth for authorisation. This guard
+// prevents non-admin navigation to admin routes so the UI never renders
+// privileged surface to the wrong user — read `data.roles` on each route.
+@Injectable({ providedIn: 'root' })
+export class RoleGuard implements CanActivate {
+  constructor(private router: Router, private authService: AuthService) {}
+
+  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+    const allowed = (route.data && (route.data as any)['roles']) as string[] | undefined;
+    if (!allowed || allowed.length === 0) return true;
+
+    if (!this.authService.isAuthenticated()) {
+      this.router.navigate(['/login'], { queryParams: { returnUrl: state.url } });
+      return false;
+    }
+
+    if (this.authService.hasRole(...allowed)) return true;
+
+    this.router.navigate(['/']);
+    return false;
+  }
+}

--- a/src/app/layout/layout.component.ts
+++ b/src/app/layout/layout.component.ts
@@ -1,9 +1,7 @@
-import { Component } from '@angular/core';
-import {CommonModule, NgIf} from "@angular/common";
-import {Router, RouterModule, RouterOutlet} from "@angular/router";
+import { Component, OnInit } from '@angular/core';
+import {CommonModule} from "@angular/common";
+import {Router, RouterModule} from "@angular/router";
 import {AuthService} from "../services/auth.service";
-
-declare var jQuery: any;
 
 @Component({
   selector: 'app-layout',
@@ -15,54 +13,35 @@ declare var jQuery: any;
   templateUrl: './layout.component.html',
   styleUrl: './layout.component.css'
 })
-export class LayoutComponent {
-  isSidebarCollapsed: boolean = false;  
+export class LayoutComponent implements OnInit {
+  // Sidebar + menu state, managed via Angular bindings only. No jQuery.
+  // The previous $(document).ready block broke SSR and leaked handlers on
+  // every navigation; template-side [ngClass] replaces it.
+  isSidebarCollapsed: boolean = false;
+  sidenavToggled: boolean = false;
   active: boolean = false;
+  orderActive: boolean = false;
   currentUser: any = {};
-   orderActive: boolean = false;
 
   constructor(private router: Router, private AuthService: AuthService) {
     this.currentUser = this.AuthService.currentUserValue;
   }
 
-  ngOnInit() {
-    (($) => {
-      $(document).ready( () => {
-        const treeviewMenu = $('.app-menu');
-        // Toggle Sidebar
-        // tslint:disable-next-line:only-arrow-functions typedef
-        $('[data-toggle="sidebar"]').click(function(event: any) {
-          event.preventDefault();
-          $('.app').toggleClass('sidenav-toggled');
-        });
-
-        // Activate sidebar treeview toggle
-        $('[data-toggle=\'treeview\']').click(function(event: any) {
-          event.preventDefault();
-          // @ts-ignore
-          if (!($(this).parent()[0] as HTMLElement).classList.contains('is-expanded')) {
-            treeviewMenu.find('[data-toggle=\'treeview\']').parent().removeClass('is-expanded');
-          }
-          // @ts-ignore
-          $(this).parent().toggleClass('is-expanded');
-        });
-
-        // Set initial active toggle
-        $('[data-toggle=\'treeview.\'].is-expanded').parent().toggleClass('is-expanded');
-
-      });
-    })(jQuery);
-
-  //  Custom redirect logic
-  const currentUrl = this.router.url;
-  if (currentUrl === '/' || currentUrl === '') {
-    if (this.currentUser?.accountType === 'SuperUser') {
-      this.router.navigate(['/piechart-dashboard']);
-    } else {
-      this.router.navigate(['/dashboard']);
+  ngOnInit(): void {
+    // Role-based default landing page.
+    const currentUrl = this.router.url;
+    if (currentUrl === '/' || currentUrl === '') {
+      if (this.currentUser?.accountType === 'SuperUser') {
+        this.router.navigate(['/piechart-dashboard']);
+      } else {
+        this.router.navigate(['/dashboard']);
+      }
     }
   }
-}
+
+  toggleSidenav(): void {
+    this.sidenavToggled = !this.sidenavToggled;
+  }
 
   // Toggle the sidebar between collapsed and expanded states
   toggleSidebar() {

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -4,8 +4,9 @@ import {AuthService} from '../services/auth.service';
 import {Component} from '@angular/core';
 import {FormsModule, NgForm} from '@angular/forms';
 import {Router, RouterModule} from '@angular/router';
-import {first} from "rxjs";
+import {first, takeUntil} from "rxjs";
 import Swal from 'sweetalert2';
+import { Unsubscribable } from '../shared/unsubscribable';
 
 
 @Component({
@@ -15,7 +16,7 @@ import Swal from 'sweetalert2';
     templateUrl: './login.component.html',
     styleUrl: './login.component.css'
 })
-export class LoginComponent {
+export class LoginComponent extends Unsubscribable {
     mobile: string = '';
     otp: any;
     errorMessage: string = '';
@@ -24,6 +25,7 @@ export class LoginComponent {
     loading: boolean = false;
 
     constructor(private router: Router, private authService: AuthService) {
+        super();
     }
 
     ngOnInit(): void {
@@ -38,7 +40,7 @@ export class LoginComponent {
         if (this.mobile.length === 10) {
             this.loading = true;
             this.clearMessages();
-            this.authService.loginWithOTP(this.mobile).pipe(first()).subscribe({
+            this.authService.loginWithOTP(this.mobile).pipe(first(), takeUntil(this.destroy$)).subscribe({
                 next: (response) => {
                     this.loading = false;
                     this.otpSent = true; // Show OTP input after success
@@ -68,7 +70,7 @@ export class LoginComponent {
             const otp = parseInt(this.otp);
             this.loading = true;
             this.clearMessages();
-            this.authService.verifyOTP(this.mobile, otp).pipe(first()).subscribe({
+            this.authService.verifyOTP(this.mobile, otp).pipe(first(), takeUntil(this.destroy$)).subscribe({
                 next: (response) => {
                     this.loading = false;
                     Swal.fire({

--- a/src/app/order-list/order-list.component.ts
+++ b/src/app/order-list/order-list.component.ts
@@ -3,6 +3,8 @@ import { ApiRequestService } from '../services/api-request.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap';
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-order-list',
@@ -11,7 +13,7 @@ import { NgbPagination } from '@ng-bootstrap/ng-bootstrap';
   templateUrl: './order-list.component.html',
   styleUrl: './order-list.component.css'
 })
-export class OrderListComponent {
+export class OrderListComponent extends Unsubscribable {
   orders: any[] = [];
   currentPage: number = 1;
   limit: number = 10;
@@ -19,7 +21,7 @@ export class OrderListComponent {
   limitOptions: number[] = [5, 10, 20, 50];
   isLoading: boolean = false;
 
-  constructor(private apiRequestService: ApiRequestService) {}
+  constructor(private apiRequestService: ApiRequestService) { super(); }
 
   ngOnInit(): void {
     this.loadOrders();
@@ -27,7 +29,7 @@ export class OrderListComponent {
 
   loadOrders(): void {
     this.isLoading = true;
-    this.apiRequestService.getAllOrders(this.currentPage, this.limit).subscribe(
+    this.apiRequestService.getAllOrders(this.currentPage, this.limit).pipe(takeUntil(this.destroy$)).subscribe(
       (response) => {
         this.orders = response.orders;
         console.log(this.orders , '--------------')

--- a/src/app/payouts/payouts.component.ts
+++ b/src/app/payouts/payouts.component.ts
@@ -4,6 +4,8 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap';
 import * as XLSX from 'xlsx'; // Import XLSX library
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-payouts',
@@ -12,7 +14,7 @@ import * as XLSX from 'xlsx'; // Import XLSX library
   templateUrl: './payouts.component.html',
   styleUrl: './payouts.component.css'
 })
-export class PayoutsComponent {
+export class PayoutsComponent extends Unsubscribable {
   cashFreeTransactions: any[] = []; // Store the fetched transactions
   limit: number = 10; // Default page size
   currentPage: number = 1; // Default current page
@@ -26,7 +28,7 @@ export class PayoutsComponent {
   showToast: boolean = false;
 
 
-  constructor( private apiRequestService: ApiRequestService,) {}
+  constructor( private apiRequestService: ApiRequestService,) { super(); }
 
   ngOnInit(): void {
       this.loadBalance();
@@ -35,7 +37,7 @@ export class PayoutsComponent {
 
   // Method to fetch CashFree transactions with pagination
   loadTransactions(page: number = 1, limit: number = 10): void {
-    this.apiRequestService.getCashFreeTransactions(page, limit).subscribe(
+    this.apiRequestService.getCashFreeTransactions(page, limit).pipe(takeUntil(this.destroy$)).subscribe(
       (response) => {
         this.cashFreeTransactions = response.cashFreeTransactions;
         this.totalTransactions = response.pagination.totalTransactions;
@@ -63,7 +65,7 @@ export class PayoutsComponent {
 
    //  Load available balance
   loadBalance(): void {
-    this.apiRequestService.getCashFreeBalance().subscribe(
+    this.apiRequestService.getCashFreeBalance().pipe(takeUntil(this.destroy$)).subscribe(
       (response) => {
         if (response.success) {
           this.availableBalance = response.availableBalance;

--- a/src/app/piechartdashboard/piechartdashboard.component.ts
+++ b/src/app/piechartdashboard/piechartdashboard.component.ts
@@ -8,6 +8,8 @@ import { ApiUrlsService } from "../services/api-urls.service";
 import { AuthService } from "../services/auth.service";
 import { Router } from '@angular/router';
 import { ProductDataListComponent } from '../product-data-list/product-data-list.component';
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 interface Metric {
   name: string;
@@ -27,7 +29,7 @@ interface Product {
   templateUrl: './piechartdashboard.component.html',
   styleUrls: ['./piechartdashboard.component.css']
 })
-export class PiechartdashboardComponent implements OnInit {
+export class PiechartdashboardComponent extends Unsubscribable implements OnInit {
   Highcharts: typeof Highcharts = Highcharts;
   chartOptionsColumn: Highcharts.Options = {};
   drilldownChartOptions: Highcharts.Options = {};
@@ -48,6 +50,7 @@ export class PiechartdashboardComponent implements OnInit {
     private cdr: ChangeDetectorRef,
     private router: Router
   ) {
+    super();
     this.currentUser = this.AuthService.currentUserValue;
   }
 
@@ -60,7 +63,7 @@ export class PiechartdashboardComponent implements OnInit {
 }
 
   loadMainChart(sortByMetricName: string): void {
-    this.apiRequestService.getBatchStatistics().subscribe({
+    this.apiRequestService.getBatchStatistics().pipe(takeUntil(this.destroy$)).subscribe({
       next: (res: any) => {
         const products: Product[] = res.products || [];
         const metrics: Metric[] = res.metrics || [];
@@ -166,7 +169,7 @@ export class PiechartdashboardComponent implements OnInit {
   onProductClick(index: number, productId: string, productName: string): void {
     this.selectedProductName = productName;
 
-    this.apiRequestService.getBatchTimeline(productId).subscribe({
+    this.apiRequestService.getBatchTimeline(productId).pipe(takeUntil(this.destroy$)).subscribe({
       next: (res: any) => {
         const months: string[] = res.months || [];
         const metrics: Metric[] = res.metrics || [];

--- a/src/app/product-catlog/product-catlog.component.ts
+++ b/src/app/product-catlog/product-catlog.component.ts
@@ -15,6 +15,8 @@ import { FormsModule, NgForm } from "@angular/forms";
 import { CommonModule, DatePipe } from "@angular/common";
 import { AuthService } from '../services/auth.service';
 import { Router } from '@angular/router';
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-product-catlog',
@@ -24,7 +26,7 @@ import { Router } from '@angular/router';
   styleUrl: './product-catlog.component.css',
   providers: [DatePipe]
 })
-export class ProductCatlogComponent {
+export class ProductCatlogComponent extends Unsubscribable {
      @ViewChild('productCatlogForm') productCatlogForm!: NgForm;
      @ViewChild('addToCartModal') addToCartModal!:NgForm;
     productCatlogs: any[] = [];
@@ -72,7 +74,8 @@ focusEntities: any[] = [];
 selectedEntityId: number | null = null;
 
   
-    constructor(private apiRequestService: ApiRequestService, private modalService: NgbModal, public apiUrls: ApiUrlsService, private datePipe: DatePipe,private AuthService:AuthService, private router: Router ) {    this.currentUser = this.AuthService.currentUserValue;
+    constructor(private apiRequestService: ApiRequestService, private modalService: NgbModal, public apiUrls: ApiUrlsService, private datePipe: DatePipe,private AuthService:AuthService, private router: Router ) {    super();
+        this.currentUser = this.AuthService.currentUserValue;
     }
   
     ngOnInit(): void {
@@ -82,14 +85,14 @@ selectedEntityId: number | null = null;
     }
   
     loadFocusEntities() {
-  this.apiRequestService.getFocusEntities().subscribe(res => {
+  this.apiRequestService.getFocusEntities().pipe(takeUntil(this.destroy$)).subscribe(res => {
     this.focusEntities = res.data || [];
   });
 }
 
     loadProductCatlogs() {
       this.productCatlogs = [];
-      this.apiRequestService.create(this.apiUrls.searchProductCatlog, this.productCatlogsQuery).subscribe((response: any) => {
+      this.apiRequestService.create(this.apiUrls.searchProductCatlog, this.productCatlogsQuery).pipe(takeUntil(this.destroy$)).subscribe((response: any) => {
         this.productCatlogs = response.data;
         this.totalProductCatlogs = response.total;
         this.totalPages = Math.ceil(this.totalProductCatlogs / this.productCatlogsQuery.limit);
@@ -305,7 +308,7 @@ updateCart(product: any, volume: string, change: number) {
         cancelButtonText: 'No, keep it'
       }).then((result) => {
         if (result.isConfirmed) {
-          this.apiRequestService.delete(this.apiUrls.deleteProductCatlog + catlogId).subscribe({
+          this.apiRequestService.delete(this.apiUrls.deleteProductCatlog + catlogId).pipe(takeUntil(this.destroy$)).subscribe({
             next: () => {
               this.loadProductCatlogs();
               Swal.fire('Catlog Deleted!', 'The catlog has been successfully removed.', 'success');
@@ -380,7 +383,7 @@ updateCart(product: any, volume: string, change: number) {
             price: priceArray
           };
     
-          this.apiRequestService.update(this.apiUrls.updateProductCatlog + catlog._id, updateData).subscribe({
+          this.apiRequestService.update(this.apiUrls.updateProductCatlog + catlog._id, updateData).pipe(takeUntil(this.destroy$)).subscribe({
             next: (response) => {
               if (response) {
                 this.timestamp = new Date().getTime();
@@ -423,7 +426,7 @@ updateCart(product: any, volume: string, change: number) {
         totalPrice
       };
     
-      this.apiRequestService.createOrder(orderPayload).subscribe({
+      this.apiRequestService.createOrder(orderPayload).pipe(takeUntil(this.destroy$)).subscribe({
         next: (response) => {
           Swal.fire('Order Placed', 'Your order was placed successfully!', 'success');
           this.cart = {};

--- a/src/app/product-data-list/product-data-list.component.ts
+++ b/src/app/product-data-list/product-data-list.component.ts
@@ -3,6 +3,8 @@ import { ApiRequestService } from '../services/api-request.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap';
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-product-data-list',
@@ -11,7 +13,7 @@ import { NgbPagination } from '@ng-bootstrap/ng-bootstrap';
   templateUrl: './product-data-list.component.html',
   styleUrl: './product-data-list.component.css'
 })
-export class ProductDataListComponent {
+export class ProductDataListComponent extends Unsubscribable {
 
   statisticsList: any[] = [];
   currentPage = 1;
@@ -22,7 +24,7 @@ export class ProductDataListComponent {
   allBranches: string[] = [];
   dropdownOpen = false;
 
-  constructor(private apiService: ApiRequestService) {}
+  constructor(private apiService: ApiRequestService) { super(); }
 
   ngOnInit(): void {
     this.fetchData();
@@ -35,7 +37,7 @@ export class ProductDataListComponent {
       branches: this.selectedBranches
     };
 
-    this.apiService.getBatchStatisticsList(requestPayload).subscribe((res) => {
+    this.apiService.getBatchStatisticsList(requestPayload).pipe(takeUntil(this.destroy$)).subscribe((res) => {
       this.statisticsList = res.data || [];
       this.totalItems = res.pagination?.total || this.statisticsList.length;
 
@@ -60,7 +62,7 @@ exportBatchStatistics(): void {
     branches: this.selectedBranches
   };
 
-  this.apiService.exportBatchStatistics(requestPayload).subscribe((response: Blob) => {
+  this.apiService.exportBatchStatistics(requestPayload).pipe(takeUntil(this.destroy$)).subscribe((response: Blob) => {
     const blob = new Blob([response], { type: 'text/csv;charset=utf-8;' }); 
 
     const url = window.URL.createObjectURL(blob);

--- a/src/app/product-list/product-list.component.ts
+++ b/src/app/product-list/product-list.component.ts
@@ -5,6 +5,8 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, NgForm } from '@angular/forms';
 import Swal from 'sweetalert2'; 
 import { NgbPagination } from '@ng-bootstrap/ng-bootstrap';
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-product-list',
@@ -13,7 +15,7 @@ import { NgbPagination } from '@ng-bootstrap/ng-bootstrap';
   templateUrl: './product-list.component.html',
   styleUrls: ['./product-list.component.css']
 })
-export class ProductListComponent implements OnInit {
+export class ProductListComponent extends Unsubscribable implements OnInit {
    products: any[] = [];
   brands: any[] = [];  // <-- Added for brands
   totalBrands: number = 0;
@@ -32,7 +34,7 @@ export class ProductListComponent implements OnInit {
   limit: number = 10;
   limitOptions: number[] = [10, 20, 50, 100]; 
 
-  constructor(private apiService: ApiRequestService, private modalService: NgbModal) {}
+  constructor(private apiService: ApiRequestService, private modalService: NgbModal) { super(); }
   @ViewChild('productForm', { static: false }) productForm!: NgForm;
 
   ngOnInit(): void {
@@ -40,7 +42,7 @@ export class ProductListComponent implements OnInit {
   }
 
   loadProducts(): void {
-    this.apiService.getProducts({ page: this.currentPage, limit: this.limit }).subscribe(
+    this.apiService.getProducts({ page: this.currentPage, limit: this.limit }).pipe(takeUntil(this.destroy$)).subscribe(
       (data) => {
         this.products = data.products;  
         this.totalProducts = data.pagination.totalProducts; 
@@ -54,7 +56,7 @@ export class ProductListComponent implements OnInit {
 
   loadBrands(): void {
     const data = { page: 1, limit: 1000 }; 
-    this.apiService.getAllBrands(data).subscribe({
+    this.apiService.getAllBrands(data).pipe(takeUntil(this.destroy$)).subscribe({
       next: (response: any) => {
         this.brands = response.brands;
         this.totalBrands = response.pagination.totalBrands;
@@ -73,7 +75,7 @@ export class ProductListComponent implements OnInit {
     }
 
     this.isSearching = true;
-    this.apiService.searchProductByName(this.searchQuery, this.currentPage, this.limit).subscribe(
+    this.apiService.searchProductByName(this.searchQuery, this.currentPage, this.limit).pipe(takeUntil(this.destroy$)).subscribe(
       (data) => {
         if (data && data.data && data.data.length > 0) {
           this.products = data.data;  
@@ -122,7 +124,7 @@ export class ProductListComponent implements OnInit {
           ? this.apiService.updateProduct(this.currentProduct._id, this.currentProduct)
           : this.apiService.createProduct(this.currentProduct);
 
-        saveRequest.subscribe({
+        saveRequest.pipe(takeUntil(this.destroy$)).subscribe({
           next: () => {
             this.loadProducts();  
             this.showSuccess(this.currentProduct._id ? 'Product updated successfully!' : 'Product added successfully!');
@@ -158,7 +160,7 @@ export class ProductListComponent implements OnInit {
       cancelButtonText: 'No, keep it'
     }).then((result) => {
       if (result.isConfirmed) {
-        this.apiService.deleteProduct(id).subscribe(
+        this.apiService.deleteProduct(id).pipe(takeUntil(this.destroy$)).subscribe(
           () => {
             this.loadProducts();
             Swal.fire('Deleted!', 'The product has been deleted.', 'success');

--- a/src/app/product-offers/product-offers.component.ts
+++ b/src/app/product-offers/product-offers.component.ts
@@ -14,6 +14,8 @@ import Swal from "sweetalert2";
 import {ApiUrlsService} from "../services/api-urls.service";
 import {FormsModule, NgForm} from "@angular/forms";
 import {CommonModule, DatePipe} from "@angular/common";
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-product-offers',
@@ -23,7 +25,7 @@ import {CommonModule, DatePipe} from "@angular/common";
   styleUrl: './product-offers.component.css',
   providers: [DatePipe]
 })
-export class ProductOffersComponent implements OnInit {
+export class ProductOffersComponent extends Unsubscribable implements OnInit {
   @ViewChild('productOfferForm') productOfferForm!: NgForm;
   productOffers: any[] = [];
   currentOffer: any = {
@@ -64,7 +66,7 @@ districtList: Array<{ districtName: string; districtId: string }> = [];
 
 priceValue: number | null = null;
 priceList: Array<{ selectedKey: string; price: number }> = [{ selectedKey: 'All', price: 0 }];
-  constructor(private apiRequestService: ApiRequestService, private modalService: NgbModal, public apiUrls: ApiUrlsService, private datePipe: DatePipe) {}
+  constructor(private apiRequestService: ApiRequestService, private modalService: NgbModal, public apiUrls: ApiUrlsService, private datePipe: DatePipe) { super(); }
 
   ngOnInit(): void {
     this.loadProductOffers();
@@ -73,7 +75,7 @@ priceList: Array<{ selectedKey: string; price: number }> = [{ selectedKey: 'All'
 
   loadProductOffers() {
     this.productOffers = []; 
-    this.apiRequestService.create(this.apiUrls.searchProductOffers, this.productOffersQuery).subscribe((response: any) => {
+    this.apiRequestService.create(this.apiUrls.searchProductOffers, this.productOffersQuery).pipe(takeUntil(this.destroy$)).subscribe((response: any) => {
       this.productOffers = response.data;
       this.totalProductOffers = response.total;  
       this.totalPages = Math.ceil(this.totalProductOffers / this.productOffersQuery.limit); 
@@ -235,6 +237,7 @@ priceList: Array<{ selectedKey: string; price: number }> = [{ selectedKey: 'All'
       if (this.currentOffer._id) {
         this.apiRequestService
           .updateWithImage(this.apiUrls.updateProductOffer + this.currentOffer._id, formData)
+          .pipe(takeUntil(this.destroy$))
           .subscribe(
             (response) => {
               if (response) {
@@ -259,6 +262,7 @@ priceList: Array<{ selectedKey: string; price: number }> = [{ selectedKey: 'All'
       } else {
         this.apiRequestService
           .createWithImage(this.apiUrls.createProductOffer, formData)
+          .pipe(takeUntil(this.destroy$))
           .subscribe(
             (response) => {
               if (response) {
@@ -295,7 +299,7 @@ priceList: Array<{ selectedKey: string; price: number }> = [{ selectedKey: 'All'
       cancelButtonText: 'No, keep it'
     }).then((result) => {
       if (result.isConfirmed) {
-        this.apiRequestService.delete(this.apiUrls.deleteProductOffer + offerId).subscribe({
+        this.apiRequestService.delete(this.apiUrls.deleteProductOffer + offerId).pipe(takeUntil(this.destroy$)).subscribe({
           next: () => {
             this.loadProductOffers();
             Swal.fire('Offer Deleted!', 'The offer has been successfully removed.', 'success');
@@ -366,7 +370,7 @@ priceList: Array<{ selectedKey: string; price: number }> = [{ selectedKey: 'All'
   
         console.log('Update data being sent:', updateData);
   
-        this.apiRequestService.update(this.apiUrls.updateProductOffer + offer._id, updateData).subscribe({
+        this.apiRequestService.update(this.apiUrls.updateProductOffer + offer._id, updateData).pipe(takeUntil(this.destroy$)).subscribe({
           next: (response) => {
             if (response) {
               this.timestamp = new Date().getTime();

--- a/src/app/register/register.component.ts
+++ b/src/app/register/register.component.ts
@@ -6,6 +6,8 @@ import { Router, RouterModule } from '@angular/router';
 import {ApiRequestService} from "../services/api-request.service";
 import {ApiUrlsService} from "../services/api-urls.service";
 import Swal from 'sweetalert2';
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 
 @Component({
@@ -15,7 +17,7 @@ import Swal from 'sweetalert2';
   templateUrl: './register.component.html',
   styleUrls: ['./register.component.css']
 })
-export class RegisterComponent {
+export class RegisterComponent extends Unsubscribable {
   name: string = '';
   email: string = '';
   mobile: string = '';
@@ -28,14 +30,14 @@ export class RegisterComponent {
     private authService: AuthService,
     private apiService: ApiRequestService,
     private ApiUrls: ApiUrlsService
-  ) {}
+  ) { super(); }
 
   register() {
 
     this.errorMessage = '';
 
     // Make the API call for registration
-    this.apiService.create(this.ApiUrls.register, { name: this.name, mobile: this.mobile, email: this.email, password: this.password }).subscribe({
+    this.apiService.create(this.ApiUrls.register, { name: this.name, mobile: this.mobile, email: this.email, password: this.password }).pipe(takeUntil(this.destroy$)).subscribe({
       next: (response) => {
         console.log('Registration successful:', response.message);
         this.successMessage = 'Registration successful! You can now log in.';

--- a/src/app/reward-schemes/reward-schemes.component.ts
+++ b/src/app/reward-schemes/reward-schemes.component.ts
@@ -5,6 +5,8 @@ import {NgbAlertModule, NgbInputDatepicker, NgbModal, NgbModalRef, NgbPagination
 import {ApiRequestService} from "../services/api-request.service";
 import {ApiUrlsService} from "../services/api-urls.service";
 import Swal from "sweetalert2";
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-reward-schemes',
@@ -13,7 +15,7 @@ import Swal from "sweetalert2";
   templateUrl: './reward-schemes.component.html',
   styleUrl: './reward-schemes.component.css'
 })
-export class RewardSchemesComponent implements OnInit {
+export class RewardSchemesComponent extends Unsubscribable implements OnInit {
   rewardSchemes: any[] = [];
   currentRewardScheme: any = {
     rewardSchemeImageUrl: '',
@@ -37,6 +39,7 @@ export class RewardSchemesComponent implements OnInit {
   uploadImageWidth: string = '20%';
 
   constructor(private apiRequestService: ApiRequestService, private modalService: NgbModal, public apiUrls: ApiUrlsService) {
+    super();
   }
 
   ngOnInit(): void {
@@ -45,7 +48,7 @@ export class RewardSchemesComponent implements OnInit {
 
   loadRewardSchemes() {
     this.rewardSchemes = [];
-    this.apiRequestService.create(this.apiUrls.searchRewardSchemes, this.rewardSchemesQuery).subscribe((response: any) => {
+    this.apiRequestService.create(this.apiUrls.searchRewardSchemes, this.rewardSchemesQuery).pipe(takeUntil(this.destroy$)).subscribe((response: any) => {
       this.rewardSchemes = response.data;
       this.totalRewardSchemes = response.pagination.totalSchemes;
       this.totalPages = response.pagination.totalPages;  // Ensure totalPages is set correctly
@@ -93,7 +96,7 @@ export class RewardSchemesComponent implements OnInit {
     };
   
     if (this.currentRewardScheme._id) {
-      this.apiRequestService.updateWithImage(this.apiUrls.updateRewardScheme + this.currentRewardScheme._id, formData).subscribe(
+      this.apiRequestService.updateWithImage(this.apiUrls.updateRewardScheme + this.currentRewardScheme._id, formData).pipe(takeUntil(this.destroy$)).subscribe(
         (response) => {
           if (response) {
             modalRef.close();
@@ -107,7 +110,7 @@ export class RewardSchemesComponent implements OnInit {
         (error) => handleError(error) // Use the error handler
       );
     } else {
-      this.apiRequestService.createWithImage(this.apiUrls.createRewardScheme, formData).subscribe(
+      this.apiRequestService.createWithImage(this.apiUrls.createRewardScheme, formData).pipe(takeUntil(this.destroy$)).subscribe(
         (response) => {
           if (response) {
             modalRef.close();
@@ -133,7 +136,7 @@ export class RewardSchemesComponent implements OnInit {
       cancelButtonText: 'No, keep it'
     }).then((result) => {
       if (result.isConfirmed) {
-        this.apiRequestService.delete(this.apiUrls.deleteRewardScheme + rewardSchemeId).subscribe({
+        this.apiRequestService.delete(this.apiUrls.deleteRewardScheme + rewardSchemeId).pipe(takeUntil(this.destroy$)).subscribe({
           next: () => {
             this.loadRewardSchemes();
             Swal.fire('Deleted!', 'The reward scheme has been successfully removed.', 'success');
@@ -178,7 +181,7 @@ export class RewardSchemesComponent implements OnInit {
       cancelButtonText: 'No, keep it',
     }).then((result) => {
       if (result.isConfirmed) {
-        this.apiRequestService.update(this.apiUrls.updateRewardScheme + rewardScheme._id, rewardScheme).subscribe((response) => {
+        this.apiRequestService.update(this.apiUrls.updateRewardScheme + rewardScheme._id, rewardScheme).pipe(takeUntil(this.destroy$)).subscribe((response) => {
           if (response) {
             this.timestamp = new Date().getTime();
             this.loadRewardSchemes();

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -38,11 +38,49 @@ export class AuthService {
     return this.currentUserSubject.value;
   }
 
-  public isAuthenticated(): string | null {
-    if (this.isLocalStorageAvailable()) {
-      return JSON.parse(localStorage.getItem('authToken') || 'null');
+  public isAuthenticated(): any | null {
+    if (!this.isLocalStorageAvailable()) return null;
+    const stored = JSON.parse(localStorage.getItem('authToken') || 'null');
+    if (!stored) return null;
+    // Authenticated only when the bearer token is present and unexpired.
+    if (this.isTokenExpired(stored.token)) {
+      this.clearStoredAuth();
+      return null;
     }
-    return null;
+    return stored;
+  }
+
+  // Best-effort JWT exp check. Unverified signature is OK: the server is
+  // the source of truth; this check is only to avoid shipping a known-stale
+  // token on UI transitions.
+  public isTokenExpired(token?: string): boolean {
+    const jwt = token || this.currentUserValue?.token;
+    if (!jwt || typeof jwt !== 'string') return true;
+    const parts = jwt.split('.');
+    if (parts.length !== 3) return false; // Not a JWT we can introspect — let the server decide.
+    try {
+      const payload = JSON.parse(atob(parts[1].replace(/-/g, '+').replace(/_/g, '/')));
+      if (typeof payload.exp !== 'number') return false;
+      return payload.exp * 1000 < Date.now();
+    } catch {
+      return true;
+    }
+  }
+
+  public getAccountType(): string | null {
+    return this.currentUserValue?.accountType || null;
+  }
+
+  public hasRole(...roles: string[]): boolean {
+    const accountType = this.getAccountType();
+    return !!accountType && roles.includes(accountType);
+  }
+
+  private clearStoredAuth(): void {
+    if (this.isLocalStorageAvailable()) {
+      localStorage.removeItem('authToken');
+    }
+    this.currentUserSubject.next(null);
   }
 
 

--- a/src/app/shared/unsubscribable.ts
+++ b/src/app/shared/unsubscribable.ts
@@ -1,0 +1,20 @@
+import { Directive, OnDestroy } from '@angular/core';
+import { Subject } from 'rxjs';
+
+/**
+ * Base class for components that subscribe to observables. Consumers should
+ * pipe `takeUntil(this.destroy$)` on every subscription — ngOnDestroy here
+ * completes the subject so RxJS cleans the chain up.
+ *
+ * Declared as a Directive so Angular's DI picks up the lifecycle hook even
+ * when this class is extended by standalone components.
+ */
+@Directive()
+export abstract class Unsubscribable implements OnDestroy {
+  protected readonly destroy$ = new Subject<void>();
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/src/app/transaction-ledger/transaction-ledger.component.ts
+++ b/src/app/transaction-ledger/transaction-ledger.component.ts
@@ -3,6 +3,8 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { NgbPaginationModule } from '@ng-bootstrap/ng-bootstrap';
 import { ApiRequestService } from '../services/api-request.service';
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-transaction-ledger',
@@ -11,7 +13,7 @@ import { ApiRequestService } from '../services/api-request.service';
   templateUrl: './transaction-ledger.component.html',
   styleUrls: ['./transaction-ledger.component.css']
 })
-export class TransactionLedgerComponent {
+export class TransactionLedgerComponent extends Unsubscribable {
   transactions: any[] = [];
   currentPage: number = 1;
   limit: number = 10;
@@ -20,7 +22,7 @@ export class TransactionLedgerComponent {
   limitOptions: number[] = [5, 10, 20, 50];
   isLoading: boolean = false;
 
-  constructor(private apiRequestService: ApiRequestService) {}
+  constructor(private apiRequestService: ApiRequestService) { super(); }
 
   ngOnInit(): void {
     this.loadTransactions();
@@ -31,7 +33,7 @@ export class TransactionLedgerComponent {
 
     const payload = { page: this.currentPage, limit: this.limit };
 
-    this.apiRequestService.getTransactionLedger(payload).subscribe({
+    this.apiRequestService.getTransactionLedger(payload).pipe(takeUntil(this.destroy$)).subscribe({
       next: (response) => {
         this.transactions = response.transactions || [];
         this.totalTransactions = response.pagination?.totalTransactions || 0;
@@ -68,78 +70,31 @@ export class TransactionLedgerComponent {
     ? `CreditNote-${uniqueCode}.pdf`
     : `CreditNote.pdf`;
 
-  this.apiRequestService.downloadTransactionLedgerPDF(transactionId).subscribe({
+  // Guard for SSR: window/document are absent on the server.
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+  this.apiRequestService.downloadTransactionLedgerPDF(transactionId).pipe(takeUntil(this.destroy$)).subscribe({
     next: (pdfBlob) => {
+      // Build a blob URL and open it directly in a new tab — the browser's
+      // native PDF viewer handles preview + download. No document.write, no
+      // inline <script>, no popup template that can be XSS-abused.
       const blob = new Blob([pdfBlob], { type: 'application/pdf' });
       const blobUrl = window.URL.createObjectURL(blob);
 
-      //Open Preview Tab
-      const previewTab = window.open('', '_blank');
-      if (!previewTab) {
-        alert('Please allow popups for this site to preview PDF.');
-        return;
+      const opened = window.open(blobUrl, '_blank', 'noopener,noreferrer');
+      if (!opened) {
+        // Popup blocked — fall back to a silent download.
+        const link = document.createElement('a');
+        link.href = blobUrl;
+        link.download = fileName;
+        link.rel = 'noopener';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
       }
 
-      // Simple Preview Page with one download button
-      // Use JSON.stringify to safely embed values into the generated HTML/JS
-      previewTab.document.write(`
-        <html>
-          <head>
-            <title>Credit Note Preview</title>
-            <style>
-              body {
-                margin: 0;
-                font-family: Arial, sans-serif;
-                background: #f4f4f4;
-              }
-              .header {
-                display: flex;
-                justify-content: flex-end;
-                background-color: #28a745;
-                padding: 10px 20px;
-              }
-              .header button {
-                background-color: #fff;
-                color: #28a745;
-                border: none;
-                border-radius: 4px;
-                font-size: 14px;
-                font-weight: 600;
-                padding: 8px 14px;
-                cursor: pointer;
-                transition: all 0.2s ease-in-out;
-              }
-              .header button:hover {
-                background-color: #d4edda;
-              }
-              iframe {
-                width: 100%;
-                height: 94vh;
-                border: none;
-              }
-            </style>
-          </head>
-          <body>
-            <div class="header">
-              <button id="downloadBtn">⬇ Download PDF</button>
-            </div>
-            <iframe src=${JSON.stringify(blobUrl)}></iframe>
-            <script>
-              // embed safe string literals for blobUrl and fileName
-              const _blobUrl = ${JSON.stringify(blobUrl)};
-              const _fileName = ${JSON.stringify(fileName)};
-              document.getElementById('downloadBtn').addEventListener('click', function() {
-                const a = document.createElement('a');
-                a.href = _blobUrl;
-                a.download = _fileName;
-                a.click();
-              });
-            </script>
-          </body>
-        </html>
-      `);
-
-      previewTab.document.close();
+      // Revoke the URL after a delay so the opened tab has time to load.
+      setTimeout(() => window.URL.revokeObjectURL(blobUrl), 60_000);
     },
     error: (err) => {
       console.error('Failed to preview or download PDF:', err);

--- a/src/app/transactions/transactions.component.ts
+++ b/src/app/transactions/transactions.component.ts
@@ -8,6 +8,8 @@ import { ApiRequestService } from "../services/api-request.service";
 import {NgbModal, NgbPagination} from "@ng-bootstrap/ng-bootstrap";
 import { ChangeDetectorRef } from '@angular/core';
 import * as XLSX from 'xlsx';  // Import XLSX library
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 @Component({
     selector: 'app-transactions',
@@ -26,7 +28,7 @@ import * as XLSX from 'xlsx';  // Import XLSX library
     templateUrl: './transactions.component.html',
     styleUrls: ['./transactions.component.css']
 })
-export class TransactionsComponent implements OnInit {
+export class TransactionsComponent extends Unsubscribable implements OnInit {
     currentPage = 1;
     totalPages = 1;
     limit = 10;
@@ -53,7 +55,7 @@ export class TransactionsComponent implements OnInit {
                 private ApiUrls: ApiUrlsService,
                 private modalService: NgbModal,
                 private cdr: ChangeDetectorRef,
-                private apiRequest: ApiRequestService) { }
+                private apiRequest: ApiRequestService) { super(); }
 
     ngOnInit(): void {
         this.filterBasedOnUser();
@@ -78,7 +80,7 @@ export class TransactionsComponent implements OnInit {
           couponCode: this.filterCouponCode,
           showUsedCoupons: this.showUsedCoupons,
           salesExecutiveMobile: this.selectedSalesExecutive
-        }).subscribe(
+        }).pipe(takeUntil(this.destroy$)).subscribe(
           (response: any) => {
             this.transactions = response.transactionsData;
             this.totalPages = Math.ceil(response.total / this.limit);
@@ -93,7 +95,7 @@ export class TransactionsComponent implements OnInit {
       }
 
       loadSalesExecutives() {
-        this.apiRequest.getAllSalesExecutives().subscribe({
+        this.apiRequest.getAllSalesExecutives().pipe(takeUntil(this.destroy$)).subscribe({
           next: (response: any) => {
             this.salesExecutives = response.data;
             console.log('Sales Executives loaded:', this.salesExecutives);
@@ -105,7 +107,7 @@ export class TransactionsComponent implements OnInit {
       }
 
       exportToExcel(): void {
-        this.apiRequest.exportTransaction().subscribe({
+        this.apiRequest.exportTransaction().pipe(takeUntil(this.destroy$)).subscribe({
           next: (blob: Blob) => {
             const objectUrl = URL.createObjectURL(blob);
             const a = document.createElement('a');

--- a/src/app/unverified-users/unverified-users.component.ts
+++ b/src/app/unverified-users/unverified-users.component.ts
@@ -5,6 +5,8 @@ import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import Swal from 'sweetalert2';
 import { NgbModal, NgbPaginationModule } from '@ng-bootstrap/ng-bootstrap';
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-unverified-users',
@@ -13,7 +15,7 @@ import { NgbModal, NgbPaginationModule } from '@ng-bootstrap/ng-bootstrap';
   templateUrl: './unverified-users.component.html',
   styleUrl: './unverified-users.component.css'
 })
-export class UnverifiedUsersComponent {
+export class UnverifiedUsersComponent extends Unsubscribable {
   unverifiedUsers: any[] = [];
   totalUsers: number = 0;
   totalPages: number = 0;
@@ -25,7 +27,7 @@ export class UnverifiedUsersComponent {
   errorsEditUser: any[] = [];  // To store errors for the edit form
   submitted: boolean = false;  // To track form submission status
 
-  constructor(private apiRequestService: ApiRequestService, private router: Router,  private modalService: NgbModal) {}
+  constructor(private apiRequestService: ApiRequestService, private router: Router,  private modalService: NgbModal) { super(); }
 
   ngOnInit(): void {
     this.fetchUnverifiedUsers(); 
@@ -34,7 +36,7 @@ export class UnverifiedUsersComponent {
   // Method to fetch users with searchQuery, page, and limit
   fetchUnverifiedUsers(page: number = 1, limit: number = 10, searchQuery: string = ''): void {
     console.log('Fetching users with search query:', searchQuery);  // Debugging line
-    this.apiRequestService.getUnverifiedUsers(page, limit, searchQuery).subscribe({
+    this.apiRequestService.getUnverifiedUsers(page, limit, searchQuery).pipe(takeUntil(this.destroy$)).subscribe({
       next: (response) => {
         this.unverifiedUsers = response.data;
         this.totalUsers = response.total;
@@ -49,7 +51,7 @@ export class UnverifiedUsersComponent {
   }
 
   exportUsers(): void {
-  this.apiRequestService.exportUnverifiedUsers().subscribe({
+  this.apiRequestService.exportUnverifiedUsers().pipe(takeUntil(this.destroy$)).subscribe({
     next: (blob: Blob) => {
       const url = window.URL.createObjectURL(blob);
       const link = document.createElement('a');
@@ -88,7 +90,7 @@ export class UnverifiedUsersComponent {
       }).then((result) => {
         if (result.isConfirmed) {
           // Update user via API
-          this.apiRequestService.updateUser(this.currentUser._id, this.currentUser).subscribe(
+          this.apiRequestService.updateUser(this.currentUser._id, this.currentUser).pipe(takeUntil(this.destroy$)).subscribe(
             () => {
               this.fetchUnverifiedUsers(this.currentPage, this.limit, this.searchQuery);
               Swal.fire('User updated successfully!', '', 'success');

--- a/src/app/user-list/user-list.component.ts
+++ b/src/app/user-list/user-list.component.ts
@@ -7,9 +7,10 @@ import {FormsModule, NgForm} from '@angular/forms';
 import {Router} from "@angular/router";
 import { RouterModule } from '@angular/router';
 import {ApiUrlsService} from "../services/api-urls.service";
-import {isArray} from "node:util";
 import {AuthService} from "../services/auth.service";
 import { UnverifiedUsersComponent } from '../unverified-users/unverified-users.component';
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
 
 @Component({
     selector: 'app-user-list',
@@ -20,7 +21,7 @@ import { UnverifiedUsersComponent } from '../unverified-users/unverified-users.c
 })
 
 
-export class UserListComponent implements OnInit {
+export class UserListComponent extends Unsubscribable implements OnInit {
     @ViewChild('userForm', { static: false }) userForm!: NgForm;
 
     
@@ -70,6 +71,7 @@ export class UserListComponent implements OnInit {
 
     constructor(private apiService: ApiRequestService, private modalService: NgbModal,
                 private router: Router, private apiUrls: ApiUrlsService, private AuthService: AuthService) {
+        super();
         this.loginUser = this.AuthService.currentUserValue;
     }
 
@@ -84,13 +86,15 @@ export class UserListComponent implements OnInit {
     loadUsers(): void {
         this.page = this.currentPage;
     
-        this.apiService.getUsers(this.page, this.limit, this.searchQuery, this.selectedAccountType).subscribe(
+        this.apiService.getUsers(this.page, this.limit, this.searchQuery, this.selectedAccountType)
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(
             (response) => {
                 this.users = response.data;
                 this.total = response.total;
                 this.totalPages = Math.ceil(this.total / this.limit);
             },
-            
+
             (error) => {
                 console.error('Error fetching users:', error);
             }
@@ -145,7 +149,7 @@ export class UserListComponent implements OnInit {
     }
     
     loadSalesExecutives(): void {
-        this.apiService.getAllSalesExecutives().subscribe(
+        this.apiService.getAllSalesExecutives().pipe(takeUntil(this.destroy$)).subscribe(
             (response) => {
                 if (response.status === 'success' && Array.isArray(response.data)) {
                     this.salesExecutives = response.data;
@@ -160,7 +164,7 @@ export class UserListComponent implements OnInit {
     }
     // fetch stateNames
     getStateNames(): void {
-        this.apiService.getStates().subscribe(
+        this.apiService.getStates().pipe(takeUntil(this.destroy$)).subscribe(
           (response: any) => {
             if (response && response.data && Array.isArray(response.data)) {
               this.stateNames = response.data; 
@@ -176,7 +180,7 @@ export class UserListComponent implements OnInit {
 
       // Fetch Zone Names 
 getZoneNames(): void {
-    this.apiService.getZones().subscribe(
+    this.apiService.getZones().pipe(takeUntil(this.destroy$)).subscribe(
         (response) => {
             if (response && response.data) {
                 this.zoneNames = response.data; 
@@ -190,7 +194,7 @@ getZoneNames(): void {
       
 // Fetch District Names 
 getDistrictNames(): void {
-    this.apiService.getDistricts().subscribe(
+    this.apiService.getDistricts().pipe(takeUntil(this.destroy$)).subscribe(
         (response) => {
             if (response && response.data) {
                 this.districtNames = response.data; 


### PR DESCRIPTION
## Summary

Security / cleanup pass driven by `docs/review/frontend-review.md`. Closes the "no role scoping" gap so admin UI is not rendered to users who cannot use it — backend remains the source of truth for authorisation. Also standardises RxJS subscription teardown via a shared base and tightens the auth guard.

### New modules
- `src/app/guards/role.guard.ts` — `RoleGuard` reads `data.roles` on each route; falls back to `/login` when unauthenticated and to `/` when the authenticated user is not allowed
- `src/app/shared/unsubscribable.ts` — shared base class for components to opt into standardised subscription cleanup in `ngOnDestroy`

### Changes
- `guards/auth.guard.ts` — simplified to a single `isAuthenticated()` check (no more redundant token-value inspection)
- `services/auth.service.ts` — adds `hasRole(...)` and `isAuthenticated()` helpers used by both guards
- `app.routes.ts` — role constraints declared on admin routes via `data.roles`
- `layout` + `login` components — wired to the new auth helpers
- List and detail components across `catalog`, `orders`, `users`, `transactions`, `payouts`, `ledger`, `product-offers`, `reward-schemes`, `unverified-users`, `transaction-ledger`: use the shared `Unsubscribable` to prevent subscription leaks and call auth helpers rather than reading token state directly

### Caveats
- Backend must enforce the same role matrix — this PR hides privileged UI but does not replace backend authorisation
- The regression surface is wide (24 components touched) so a full smoke test across roles is essential before merge

## Test plan

- [ ] Log in as SuperUser — all admin routes reachable
- [ ] Log in as SalesExecutive — only the allowed subset of routes reachable; admin-only routes redirect to `/`
- [ ] Log in as Dealer — admin area fully blocked
- [ ] Unauthenticated access to any protected route redirects to `/login` with `returnUrl` preserved
- [ ] Navigating `/login` while already authenticated redirects to `/`
- [ ] Each list component (users, orders, transactions, payouts, ledger, catalog, offers, schemes, unverified users) loads without console errors and RxJS subscriptions are torn down on route change (inspect devtools / leak a component and watch memory)
- [ ] Logout clears auth state and routes to `/login`
