### PR TITLE
feat: order list overhaul, Focus Sync retry, warehouse/branch checkout, pagination consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ Thumbs.db
 package-lock.json
 
 public
+.wolf
+.claude

--- a/src/app/batch-list/batch-list.component.html
+++ b/src/app/batch-list/batch-list.component.html
@@ -66,25 +66,20 @@
                 </tbody>
             </table>
         </div>
-        <div class="row">
-            <div class="col-sm-12 text-right">
-              <div class="d-flex justify-content-end">
-                <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select mx-2" style="width:100px; margin-bottom: 16px">
-                  <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
-                </select>
-          
-                <!-- Pagination Controls -->
-                <ngb-pagination class="mx-2"
-                                [(page)]="currentPage"
-                                [pageSize]="limit"
-                                [collectionSize]="totalBranches"
-                                [boundaryLinks]="true"
-                                (pageChange)="handlePageChange($event)"
-                                [maxSize]="5">
-                </ngb-pagination>
-              </div>
-            </div>
-          </div>
+        <div class="pagination-row">
+          <span class="page-size-label">Rows per page</span>
+          <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select">
+            <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
+          </select>
+          <ngb-pagination
+            [(page)]="currentPage"
+            [pageSize]="limit"
+            [collectionSize]="totalBranches"
+            [boundaryLinks]="true"
+            (pageChange)="handlePageChange($event)"
+            [maxSize]="5">
+          </ngb-pagination>
+        </div>
           
   
 <!-- Update Branch Modal -->

--- a/src/app/brand-list/brand-list.component.html
+++ b/src/app/brand-list/brand-list.component.html
@@ -42,25 +42,19 @@
   </div>
 
   <!-- Pagination Controls -->
-  <div class="row">
-    <div class="col-sm-12 text-right">
-      <div class="d-flex justify-content-end">
-        <!-- Page Size Selector -->
-        <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select mx-2" style="width:100px; margin-bottom: 16px">
-          <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
-        </select>
-
-        <!-- Pagination Controls -->
-        <ngb-pagination class="mx-2"
-                        [(page)]="currentPage"
-                        [pageSize]="limit"
-                        [collectionSize]="totalBrands"
-                        [boundaryLinks]="true"
-                        (pageChange)="handlePageChange($event)"
-                        [maxSize]="5">
-        </ngb-pagination>
-      </div>
-    </div>
+  <div class="pagination-row">
+    <span class="page-size-label">Rows per page</span>
+    <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select">
+      <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
+    </select>
+    <ngb-pagination
+      [(page)]="currentPage"
+      [pageSize]="limit"
+      [collectionSize]="totalBrands"
+      [boundaryLinks]="true"
+      (pageChange)="handlePageChange($event)"
+      [maxSize]="5">
+    </ngb-pagination>
   </div>
 
   <!-- Modal Template -->

--- a/src/app/credit-notes/credit-notes.component.html
+++ b/src/app/credit-notes/credit-notes.component.html
@@ -112,24 +112,19 @@
   </div>
 
   <!-- Pagination -->
-  <div class="row">
-    <div class="col-sm-12 text-right">
-      <div class="d-flex justify-content-end align-items-center">
-        <select [(ngModel)]="limit" (change)="handleLimitChange()"
-                class="form-select mx-2" style="width: 100px; margin-bottom: 16px;">
-          <option *ngFor="let opt of limitOptions" [value]="opt">{{ opt }}</option>
-        </select>
-        <ngb-pagination
-          class="mx-2"
-          [(page)]="currentPage"
-          [pageSize]="limit"
-          [collectionSize]="total"
-          [boundaryLinks]="true"
-          (pageChange)="handlePageChange($event)"
-          [maxSize]="5">
-        </ngb-pagination>
-      </div>
-    </div>
+  <div class="pagination-row">
+    <span class="page-size-label">Rows per page</span>
+    <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select">
+      <option *ngFor="let opt of limitOptions" [value]="opt">{{ opt }}</option>
+    </select>
+    <ngb-pagination
+      [(page)]="currentPage"
+      [pageSize]="limit"
+      [collectionSize]="total"
+      [boundaryLinks]="true"
+      (pageChange)="handlePageChange($event)"
+      [maxSize]="5">
+    </ngb-pagination>
   </div>
 </div>
 

--- a/src/app/order-list/order-list.component.css
+++ b/src/app/order-list/order-list.component.css
@@ -1,0 +1,112 @@
+.order-table {
+  font-size: 0.875rem;
+}
+
+/* Summary row */
+.summary-row {
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+.summary-row:hover {
+  background-color: #f0f4f8;
+}
+.summary-row td {
+  vertical-align: middle;
+  padding: 0.75rem 0.75rem;
+}
+
+.expand-toggle {
+  color: #adb5bd;
+  font-size: 1.1rem;
+  width: 36px;
+}
+
+/* Expanded detail panel */
+.detail-row td {
+  padding: 0;
+  background-color: #f8fafc;
+  border-top: none;
+}
+.detail-panel {
+  padding: 1rem 1.25rem 1.25rem;
+  border-top: 2px solid #2C3E50;
+}
+
+.detail-section {
+  margin-bottom: 1.25rem;
+}
+.detail-label {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #8a94a0;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+}
+
+/* Items table inside expanded row */
+.items-table {
+  font-size: 0.82rem;
+  background: white;
+  border-radius: 6px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+}
+.items-table thead th {
+  background-color: #f0f4f8;
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: #4a5568;
+  border-bottom: 1px solid #dee2e6;
+  padding: 0.5rem 0.75rem;
+}
+.items-table tbody td {
+  padding: 0.5rem 0.75rem;
+  border-color: #f0f4f8;
+}
+
+/* Meta row: amount + focus + details side by side */
+.detail-meta-row {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+.detail-meta-row .detail-section {
+  min-width: 180px;
+  background: white;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  margin-bottom: 0;
+}
+
+.meta-kv {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.82rem;
+  padding: 0.2rem 0;
+}
+.meta-kv + .meta-kv {
+  border-top: 1px solid #f0f4f8;
+}
+
+/* Status filter pills */
+.filter-btn {
+  font-size: 0.78rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 20px;
+  border: 1px solid #dee2e6;
+  color: #4a5568;
+  background: white;
+  transition: all 0.15s;
+}
+.filter-btn:hover {
+  background-color: #f0f4f8;
+  border-color: #adb5bd;
+}
+.filter-btn.active {
+  background-color: #2C3E50;
+  border-color: #2C3E50;
+  color: white;
+}

--- a/src/app/order-list/order-list.component.html
+++ b/src/app/order-list/order-list.component.html
@@ -1,59 +1,203 @@
 <div class="container-fluid container-mt shadow-sm">
-  <div class="row mb-4">
-    <div class="col-sm-2">
-      <h4>Orders</h4>
-    </div>
-    <div class="col-sm-10 d-flex justify-content-end">
-    </div>
+
+  <!-- Header + filters -->
+  <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+    <h5 class="mb-0 me-auto">Orders</h5>
+    <button class="btn btn-sm filter-btn"
+            [class.active]="statusFilter === ''"
+            (click)="setStatusFilter('')">All</button>
+    <button *ngFor="let s of statusOptions"
+            class="btn btn-sm filter-btn"
+            [class.active]="statusFilter === s"
+            (click)="setStatusFilter(s)">{{ s }}</button>
   </div>
 
-  <div class="table-wrapper">
-    <table class="table table-hover">
-      <thead class="thead-dark">
+  <!-- Loading -->
+  <div *ngIf="isLoading" class="text-center py-5">
+    <div class="spinner-border text-secondary" role="status"></div>
+  </div>
+
+  <!-- Table -->
+  <div class="table-wrapper" *ngIf="!isLoading">
+    <table class="table table-hover order-table">
+      <thead>
         <tr>
-          <th scope="col">S.NO</th>
-          <th scope="col">Order ID</th>
-          <th scope="col">Customer Name</th> 
-          <th scope="col">Status</th>
-          <th scope="col">Order Date</th>
-          <th scope="col">Total Amount</th>
+          <th>#</th>
+          <th>Order</th>
+          <th>Customer</th>
+          <th>Status</th>
+          <th>Focus Sync</th>
+          <th>Date</th>
+          <th class="text-end">Amount</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
-        <tr *ngFor="let order of orders; let i = index">
-          <td>{{ (currentPage - 1) * limit + i + 1 }}</td>
-          <td>{{ order.orderId }}</td>
-          <td>{{ order.createdBy.name }}</td>
-          <td>{{order.status}}</td>
-          <td>{{ order.createdAt | date: 'short' }}</td>
-          <td>{{ order.finalPrice | currency:'INR' }}</td>             
-        </tr>
-        <tr *ngIf="orders.length === 0">
-          <td class="text-center" colspan="6">No Records found</td>
+        <ng-container *ngFor="let order of filteredOrders; let i = index">
+
+          <!-- Summary row -->
+          <tr class="summary-row" (click)="toggleExpand(order.orderId)">
+            <td class="text-muted">{{ (currentPage - 1) * limit + i + 1 }}</td>
+
+            <td>
+              <div class="fw-semibold">{{ order.orderId }}</div>
+              <small *ngIf="order.focusOrderId" class="text-muted">
+                <i class="bx bx-link-alt"></i> {{ order.focusOrderId }}
+              </small>
+            </td>
+
+            <td>
+              <div>{{ order.createdBy?.name || '—' }}</div>
+              <small class="text-muted">{{ order.createdBy?.mobile }}</small>
+              <div *ngIf="order.dealerId && order.dealerId?._id !== order.createdBy?._id">
+                <small class="text-muted">For: {{ order.dealerId?.name }}</small>
+              </div>
+            </td>
+
+            <td>
+              <span class="badge" [ngClass]="getBadgeClass(order.status)">
+                {{ order.status }}
+              </span>
+            </td>
+
+            <td>
+              <span class="badge" [ngClass]="getFocusBadgeClass(order.focusSyncStatus)">
+                {{ order.focusSyncStatus || 'PENDING' }}
+              </span>
+            </td>
+
+            <td>{{ order.createdAt | date: 'dd MMM yyyy' }}</td>
+
+            <td class="text-end fw-semibold">
+              {{ order.finalPrice | currency:'INR':'symbol':'1.0-0' }}
+            </td>
+
+            <td class="text-center expand-toggle">
+              <i class="bx"
+                 [class.bx-chevron-down]="expandedOrderId !== order.orderId"
+                 [class.bx-chevron-up]="expandedOrderId === order.orderId"></i>
+            </td>
+          </tr>
+
+          <!-- Expanded detail row -->
+          <tr *ngIf="expandedOrderId === order.orderId" class="detail-row">
+            <td colspan="8">
+              <div class="detail-panel">
+
+                <!-- Items -->
+                <div class="detail-section">
+                  <div class="detail-label">ITEMS</div>
+                  <table class="table table-sm items-table mb-0">
+                    <thead>
+                      <tr>
+                        <th>Product</th>
+                        <th>Volume</th>
+                        <th class="text-center">Qty</th>
+                        <th class="text-end">Unit Price</th>
+                        <th class="text-end">Subtotal</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr *ngFor="let item of order.items">
+                        <td>{{ item.productOfferDescription }}</td>
+                        <td>{{ item.volume || '—' }}</td>
+                        <td class="text-center">{{ item.quantity }}</td>
+                        <td class="text-end">{{ item.productPrice | currency:'INR':'symbol':'1.0-0' }}</td>
+                        <td class="text-end fw-semibold">{{ itemSubtotal(item) | currency:'INR':'symbol':'1.0-0' }}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+
+                <!-- Financials + Meta -->
+                <div class="detail-meta-row">
+
+                  <!-- Price breakdown -->
+                  <div class="detail-section flex-grow-1">
+                    <div class="detail-label">AMOUNT</div>
+                    <div class="meta-kv">
+                      <span class="text-muted">Subtotal</span>
+                      <span>{{ order.totalPrice | currency:'INR':'symbol':'1.2-2' }}</span>
+                    </div>
+                    <div class="meta-kv">
+                      <span class="text-muted">GST</span>
+                      <span>{{ order.gstPrice | currency:'INR':'symbol':'1.2-2' }}</span>
+                    </div>
+                    <div class="meta-kv fw-semibold">
+                      <span>Total</span>
+                      <span>{{ order.finalPrice | currency:'INR':'symbol':'1.2-2' }}</span>
+                    </div>
+                  </div>
+
+                  <!-- Focus details -->
+                  <div class="detail-section flex-grow-1">
+                    <div class="detail-label">FOCUS SYNC</div>
+                    <div class="meta-kv" *ngIf="order.focusOrderId">
+                      <span class="text-muted">Voucher No</span>
+                      <span class="fw-semibold">{{ order.focusOrderId }}</span>
+                    </div>
+                    <div class="meta-kv" *ngIf="order.focusDCInvoiceId?.length">
+                      <span class="text-muted">DC Invoices</span>
+                      <span>{{ order.focusDCInvoiceId.join(', ') }}</span>
+                    </div>
+                    <div *ngIf="order.focusSyncStatus === 'FAILED'" class="mt-2">
+                      <button class="btn btn-sm btn-outline-danger"
+                              [disabled]="isRetrying[order.orderId]"
+                              (click)="retryFocusSync($event, order)">
+                        <span *ngIf="isRetrying[order.orderId]"
+                              class="spinner-border spinner-border-sm me-1"></span>
+                        Retry Sync
+                      </button>
+                      <small *ngIf="retryMessage[order.orderId]"
+                             class="ms-2 text-muted">{{ retryMessage[order.orderId] }}</small>
+                    </div>
+                  </div>
+
+                  <!-- Order meta -->
+                  <div class="detail-section flex-grow-1">
+                    <div class="detail-label">DETAILS</div>
+                    <div class="meta-kv" *ngIf="order.narration">
+                      <span class="text-muted">Narration</span>
+                      <span>{{ order.narration }}</span>
+                    </div>
+                    <div class="meta-kv" *ngIf="order.dealerId?.name">
+                      <span class="text-muted">Dealer</span>
+                      <span>{{ order.dealerId?.name }}<span *ngIf="order.dealerId?.dealerCode" class="text-muted"> ({{ order.dealerId?.dealerCode }})</span></span>
+                    </div>
+                    <div class="meta-kv">
+                      <span class="text-muted">Placed by</span>
+                      <span>{{ order.createdBy?.name }} <span class="badge bg-light text-dark ms-1" style="font-size:10px">{{ order.createdBy?.accountType }}</span></span>
+                    </div>
+                  </div>
+
+                </div>
+              </div>
+            </td>
+          </tr>
+
+        </ng-container>
+
+        <tr *ngIf="filteredOrders.length === 0">
+          <td colspan="8" class="text-center text-muted py-4">No orders found</td>
         </tr>
       </tbody>
     </table>
-  </div> 
-    
-     <!-- Pagination Controls -->
-  <div class="row">
-    <div class="col-sm-12 text-right">
-      <div class="d-flex justify-content-end">
-        <!-- Page Size Selector -->
-        <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select mx-2" style="width:100px; margin-bottom: 16px;">
-          <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
-        </select>  
-
-        <!-- Pagination Controls -->
-        <ngb-pagination class="mx-2"
-                        [(page)]="currentPage"
-                        [pageSize]="limit"
-                        [collectionSize]="totalOrders"
-                        [boundaryLinks]="true"
-                        (pageChange)="handlePageChange($event)"
-                        [maxSize]="5">
-        </ngb-pagination>
-      </div>
-    </div>
   </div>
+
+  <!-- Pagination -->
+  <div class="pagination-row">
+    <span class="page-size-label">Rows per page</span>
+    <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select form-select-sm">
+      <option *ngFor="let o of limitOptions" [value]="o">{{ o }}</option>
+    </select>
+    <ngb-pagination
+      [(page)]="currentPage"
+      [pageSize]="limit"
+      [collectionSize]="totalOrders"
+      [boundaryLinks]="true"
+      (pageChange)="handlePageChange($event)"
+      [maxSize]="5">
+    </ngb-pagination>
+  </div>
+
 </div>

--- a/src/app/order-list/order-list.component.ts
+++ b/src/app/order-list/order-list.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ApiRequestService } from '../services/api-request.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -13,43 +13,104 @@ import { takeUntil } from 'rxjs';
   templateUrl: './order-list.component.html',
   styleUrl: './order-list.component.css'
 })
-export class OrderListComponent extends Unsubscribable {
+export class OrderListComponent extends Unsubscribable implements OnInit {
   orders: any[] = [];
-  currentPage: number = 1;
-  limit: number = 10;
-  totalOrders: number = 0;
-  limitOptions: number[] = [5, 10, 20, 50];
-  isLoading: boolean = false;
+  currentPage = 1;
+  limit = 10;
+  totalOrders = 0;
+  limitOptions = [5, 10, 20, 50];
+  isLoading = false;
+  expandedOrderId: string | null = null;
+  statusFilter = '';
+  isRetrying: { [key: string]: boolean } = {};
+  retryMessage: { [key: string]: string } = {};
+
+  readonly statusOptions = ['PENDING', 'VERIFIED', 'REJECTED', 'DISPATCHED', 'IN-PARCEL'];
 
   constructor(private apiRequestService: ApiRequestService) { super(); }
 
-  ngOnInit(): void {
-    this.loadOrders();
-  }
+  ngOnInit(): void { this.loadOrders(); }
 
   loadOrders(): void {
     this.isLoading = true;
-    this.apiRequestService.getAllOrders(this.currentPage, this.limit).pipe(takeUntil(this.destroy$)).subscribe(
-      (response) => {
-        this.orders = response.orders;
-        console.log(this.orders , '--------------')
-        this.totalOrders = response.total;
-        this.isLoading = false;
-      },
-      (error) => {
-        console.error('Error fetching orders:', error);
-        this.isLoading = false;
-      }
-    );
+    this.apiRequestService.getAllOrders(this.currentPage, this.limit)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (response) => {
+          this.orders = response.orders;
+          this.totalOrders = response.total;
+          this.isLoading = false;
+        },
+        error: () => { this.isLoading = false; }
+      });
+  }
+
+  get filteredOrders(): any[] {
+    if (!this.statusFilter) return this.orders;
+    return this.orders.filter(o => o.status === this.statusFilter);
+  }
+
+  toggleExpand(orderId: string): void {
+    this.expandedOrderId = this.expandedOrderId === orderId ? null : orderId;
+  }
+
+  getBadgeClass(status: string): string {
+    switch ((status || '').toUpperCase()) {
+      case 'VERIFIED':   return 'bg-primary';
+      case 'PENDING':    return 'bg-warning text-dark';
+      case 'REJECTED':   return 'bg-danger';
+      case 'DISPATCHED': return 'bg-success';
+      case 'IN-PARCEL':  return 'bg-info text-dark';
+      default:           return 'bg-secondary';
+    }
+  }
+
+  getFocusBadgeClass(status: string): string {
+    switch ((status || '').toUpperCase()) {
+      case 'SUCCESS': return 'bg-success';
+      case 'FAILED':  return 'bg-danger';
+      default:        return 'bg-warning text-dark';
+    }
+  }
+
+  retryFocusSync(event: Event, order: any): void {
+    event.stopPropagation();
+    if (this.isRetrying[order.orderId]) return;
+    this.isRetrying[order.orderId] = true;
+    this.retryMessage[order.orderId] = '';
+    this.apiRequestService.retryFocusSync(order.orderId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          order.focusSyncStatus = 'PENDING';
+          this.retryMessage[order.orderId] = 'Retry initiated';
+          this.isRetrying[order.orderId] = false;
+        },
+        error: (err: any) => {
+          this.retryMessage[order.orderId] = err?.error?.message || 'Retry failed';
+          this.isRetrying[order.orderId] = false;
+        }
+      });
+  }
+
+  itemSubtotal(item: any): number {
+    return (item.productPrice || 0) * (item.quantity || 0);
+  }
+
+  setStatusFilter(s: string): void {
+    this.statusFilter = s;
+    this.expandedOrderId = null;
   }
 
   handlePageChange(page: number): void {
     this.currentPage = page;
+    this.expandedOrderId = null;
     this.loadOrders();
   }
 
   handleLimitChange(): void {
     this.currentPage = 1;
+    this.expandedOrderId = null;
     this.loadOrders();
   }
 }

--- a/src/app/payouts/payouts.component.html
+++ b/src/app/payouts/payouts.component.html
@@ -64,23 +64,17 @@
 </div>
   
   <!-- Pagination Controls -->
-  <div class="row">
-    <div class="col-sm-12 text-right">
-      <div class="d-flex justify-content-end">
-        <!-- Page Size Selector -->
-        <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select mx-2" style="width:100px; margin-bottom: 16px;">
-          <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
-        </select>
-  
-        <!-- Pagination Controls -->
-        <ngb-pagination class="mx-2"
-                        [(page)]="currentPage"
-                        [pageSize]="limit"
-                        [collectionSize]="totalTransactions"
-                        [boundaryLinks]="true"
-                        (pageChange)="handlePageChange($event)"
-                        [maxSize]="5">
-        </ngb-pagination>
-      </div>
-    </div>
+  <div class="pagination-row">
+    <span class="page-size-label">Rows per page</span>
+    <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select">
+      <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
+    </select>
+    <ngb-pagination
+      [(page)]="currentPage"
+      [pageSize]="limit"
+      [collectionSize]="totalTransactions"
+      [boundaryLinks]="true"
+      (pageChange)="handlePageChange($event)"
+      [maxSize]="5">
+    </ngb-pagination>
   </div>

--- a/src/app/product-catlog/product-catlog.component.html
+++ b/src/app/product-catlog/product-catlog.component.html
@@ -83,21 +83,19 @@
 
 <div class="container-fluid my-4">
   <!-- Pagination Controls -->
-  <div class="row">
-    <div class="col-sm-12 text-right">
-      <div class="d-flex justify-content-end">
-        <!-- Page Size Selector -->
-        <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select mx-2"
-          style="width:100px; margin-bottom: 16px">
-          <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
-        </select>
-
-        <ngb-pagination class="mx-2" [(page)]="productCatlogsQuery.page" [pageSize]="productCatlogsQuery.limit"
-          [collectionSize]="totalProductCatlogs" [boundaryLinks]="true" (pageChange)="handlePageChange($event)"
-          [maxSize]="5">
-        </ngb-pagination>
-      </div>
-    </div>
+  <div class="pagination-row">
+    <span class="page-size-label">Rows per page</span>
+    <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select">
+      <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
+    </select>
+    <ngb-pagination
+      [(page)]="productCatlogsQuery.page"
+      [pageSize]="productCatlogsQuery.limit"
+      [collectionSize]="totalProductCatlogs"
+      [boundaryLinks]="true"
+      (pageChange)="handlePageChange($event)"
+      [maxSize]="5">
+    </ngb-pagination>
   </div>
 </div>
 
@@ -209,28 +207,72 @@
         </li>
 
       </ul>
-      <!-- Entity Dropdown -->
-<div class="mt-3">
-  <label class="form-label fw-semibold">
-    Select Entity
-  </label>
+      <!-- Focus Fields -->
+      <div class="mt-3 d-flex flex-column gap-3">
 
-  <ng-select
-    [items]="focusEntities"
-    bindLabel="sName"
-    bindValue="iMasterId"
-    [(ngModel)]="selectedEntityId"
-    name="entityId"
-    placeholder="Select Entity"
-    [searchable]="true"
-    [clearable]="true">
-  </ng-select>
+        <!-- Entity -->
+        <div>
+          <label class="form-label fw-semibold mb-1">Select Entity</label>
+          <ng-select
+            [items]="focusEntities"
+            bindLabel="sName"
+            bindValue="iMasterId"
+            [(ngModel)]="selectedEntityId"
+            placeholder="Select Entity"
+            [searchable]="true"
+            [clearable]="true">
+          </ng-select>
+          <div *ngIf="submitted && !selectedEntityId" class="text-danger small mt-1">
+            Entity is required
+          </div>
+        </div>
 
-  <div *ngIf="submitted && !selectedEntityId"
-       class="text-danger small mt-1">
-    Entity is required
-  </div>
-</div>
+        <!-- Warehouse -->
+        <div>
+          <label class="form-label fw-semibold mb-1">Select Warehouse</label>
+          <ng-select
+            [items]="focusWarehouses"
+            bindLabel="sName"
+            bindValue="iMasterId"
+            [(ngModel)]="selectedWarehouseId"
+            placeholder="Select Warehouse"
+            [searchable]="true"
+            [clearable]="true">
+          </ng-select>
+          <div *ngIf="submitted && !selectedWarehouseId" class="text-danger small mt-1">
+            Warehouse is required
+          </div>
+        </div>
+
+        <!-- Branch -->
+        <div>
+          <label class="form-label fw-semibold mb-1">Select Branch</label>
+          <ng-select
+            [items]="focusBranches"
+            bindLabel="sName"
+            bindValue="iMasterId"
+            [(ngModel)]="selectedBranchId"
+            placeholder="Select Branch"
+            [searchable]="true"
+            [clearable]="true">
+          </ng-select>
+          <div *ngIf="submitted && !selectedBranchId" class="text-danger small mt-1">
+            Branch is required
+          </div>
+        </div>
+
+        <!-- Narration -->
+        <div>
+          <label class="form-label fw-semibold mb-1">Narration <span class="text-muted fw-normal">(optional)</span></label>
+          <textarea
+            class="form-control"
+            [(ngModel)]="narration"
+            placeholder="Enter narration..."
+            rows="2">
+          </textarea>
+        </div>
+
+      </div>
 
     </div>
 

--- a/src/app/product-catlog/product-catlog.component.ts
+++ b/src/app/product-catlog/product-catlog.component.ts
@@ -72,6 +72,11 @@ priceList: Array<{ volume: string, entries: Array<{ selectedKey: string, price: 
  
 focusEntities: any[] = [];
 selectedEntityId: number | null = null;
+focusWarehouses: any[] = [];
+selectedWarehouseId: number | null = null;
+focusBranches: any[] = [];
+selectedBranchId: number | null = null;
+narration: string = '';
 
   
     constructor(private apiRequestService: ApiRequestService, private modalService: NgbModal, public apiUrls: ApiUrlsService, private datePipe: DatePipe,private AuthService:AuthService, private router: Router ) {    super();
@@ -81,12 +86,26 @@ selectedEntityId: number | null = null;
     ngOnInit(): void {
       this.loadProductCatlogs();
       this.getAllStatesZonesAndDistricts();
-       this.loadFocusEntities();
+      this.loadFocusEntities();
+      this.loadFocusWarehouses();
+      this.loadFocusBranches();
     }
   
     loadFocusEntities() {
   this.apiRequestService.getFocusEntities().pipe(takeUntil(this.destroy$)).subscribe(res => {
     this.focusEntities = res.data || [];
+  });
+}
+
+loadFocusWarehouses() {
+  this.apiRequestService.getFocusWarehouses().pipe(takeUntil(this.destroy$)).subscribe(res => {
+    this.focusWarehouses = res.warehouses || [];
+  });
+}
+
+loadFocusBranches() {
+  this.apiRequestService.getFocusBranches().pipe(takeUntil(this.destroy$)).subscribe(res => {
+    this.focusBranches = res.warehouses || [];
   });
 }
 
@@ -402,34 +421,51 @@ updateCart(product: any, volume: string, change: number) {
     
 
     proceedToCheckout() {
+      this.submitted = true;
+
+      if (!this.selectedEntityId || !this.selectedWarehouseId || !this.selectedBranchId) {
+        return;
+      }
+
       const items = Object.keys(this.cart).map(id => {
-         const cartItem = this.cart[id]; 
+        const cartItem = this.cart[id];
         const product = this.getProductById(id);
         const count = this.cart[id].count;
         const price = this.cart[id].price;
-    
+
         return {
-          _id: cartItem.productId,          
-         volume: cartItem.volume,
+          _id: cartItem.productId,
+          volume: cartItem.volume,
           productOfferDescription: product?.productOfferDescription || product?.productDescription || '',
           productPrice: price,
           quantity: count,
           subtotal: price * count
         };
       });
-    
+
       const totalPrice = items.reduce((sum, item) => sum + item.subtotal, 0);
-    
-      const orderPayload = {
+
+      const orderPayload: any = {
         entityId: this.selectedEntityId,
+        warehouseId: this.selectedWarehouseId,
+        branchId: this.selectedBranchId,
         items,
         totalPrice
       };
-    
+
+      if (this.narration?.trim()) {
+        orderPayload.narration = this.narration.trim();
+      }
+
       this.apiRequestService.createOrder(orderPayload).pipe(takeUntil(this.destroy$)).subscribe({
         next: (response) => {
           Swal.fire('Order Placed', 'Your order was placed successfully!', 'success');
           this.cart = {};
+          this.submitted = false;
+          this.selectedEntityId = null;
+          this.selectedWarehouseId = null;
+          this.selectedBranchId = null;
+          this.narration = '';
           this.modalService.dismissAll();
         },
         error: (err) => {

--- a/src/app/product-data-list/product-data-list.component.html
+++ b/src/app/product-data-list/product-data-list.component.html
@@ -77,23 +77,18 @@
   </div>
 
   <!-- Pagination Controls -->
-  <div class="row">
-    <div class="col-sm-12 text-right">
-      <div class="d-flex justify-content-end">
-        <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select mx-2" style="width: 100px; margin-bottom: 16px;">
-          <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
-        </select>
-
-        <ngb-pagination
-          class="mx-2"
-          [(page)]="currentPage"
-          [pageSize]="limit"
-          [collectionSize]="totalItems"
-          [boundaryLinks]="true"
-          (pageChange)="handlePageChange($event)"
-          [maxSize]="5">
-        </ngb-pagination>
-      </div>
-    </div>
+  <div class="pagination-row">
+    <span class="page-size-label">Rows per page</span>
+    <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select">
+      <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
+    </select>
+    <ngb-pagination
+      [(page)]="currentPage"
+      [pageSize]="limit"
+      [collectionSize]="totalItems"
+      [boundaryLinks]="true"
+      (pageChange)="handlePageChange($event)"
+      [maxSize]="5">
+    </ngb-pagination>
   </div>
 </div>

--- a/src/app/product-list/product-list.component.html
+++ b/src/app/product-list/product-list.component.html
@@ -43,23 +43,19 @@
   </div>
 
   <!-- Pagination Controls -->
-  <div class="row">
-    <div class="col-sm-12 text-right">
-      <div class="d-flex justify-content-end">
-        <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select mx-2" style="width:100px; margin-bottom: 16px">
-          <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
-        </select>
-
-        <ngb-pagination class="mx-2"
-                        [(page)]="currentPage"
-                        [pageSize]="limit"
-                        [collectionSize]="totalProducts"
-                        [boundaryLinks]="true"
-                        (pageChange)="handlePageChange($event)"
-                        [maxSize]="5">
-        </ngb-pagination>
-      </div>
-    </div>
+  <div class="pagination-row">
+    <span class="page-size-label">Rows per page</span>
+    <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select">
+      <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
+    </select>
+    <ngb-pagination
+      [(page)]="currentPage"
+      [pageSize]="limit"
+      [collectionSize]="totalProducts"
+      [boundaryLinks]="true"
+      (pageChange)="handlePageChange($event)"
+      [maxSize]="5">
+    </ngb-pagination>
   </div>
 
  

--- a/src/app/product-offers/product-offers.component.html
+++ b/src/app/product-offers/product-offers.component.html
@@ -49,27 +49,22 @@
 </div>
 
 <div class="container-fluid my-4">
-    <!-- Pagination Controls -->
-    <div class="row">
-      <div class="col-sm-12 text-right">
-        <div class="d-flex justify-content-end">
-          <!-- Page Size Selector -->
-          <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select mx-2" style="width:100px; margin-bottom: 16px">
-            <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
-          </select>
-  
-          <ngb-pagination class="mx-2"
-          [(page)]="productOffersQuery.page"
-          [pageSize]="productOffersQuery.limit"
-          [collectionSize]="totalProductOffers"
-          [boundaryLinks]="true"
-          (pageChange)="handlePageChange($event)"
-          [maxSize]="5">
-</ngb-pagination>
-        </div>
-      </div>
-    </div>
+  <!-- Pagination Controls -->
+  <div class="pagination-row">
+    <span class="page-size-label">Rows per page</span>
+    <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select">
+      <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
+    </select>
+    <ngb-pagination
+      [(page)]="productOffersQuery.page"
+      [pageSize]="productOffersQuery.limit"
+      [collectionSize]="totalProductOffers"
+      [boundaryLinks]="true"
+      (pageChange)="handlePageChange($event)"
+      [maxSize]="5">
+    </ngb-pagination>
   </div>
+</div>
   
 
 

--- a/src/app/reward-schemes/reward-schemes.component.html
+++ b/src/app/reward-schemes/reward-schemes.component.html
@@ -49,27 +49,21 @@
 
 
 <div class="container-fluid my-4">
-    <div class="row">
-        <div class="col-sm-12 text-right">
-            <div class="d-flex justify-content-end">
-                <!-- Page Size Selector -->
-                <select [(ngModel)]="rewardSchemesQuery.limit" (change)="handleLimitChange()" class="form-select mx-2" style="width:100px; margin-bottom: 16px">
-                    <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
-                </select>
-    
-                <!-- Pagination Component -->
-                <ngb-pagination 
-                    class="mx-2"
-                    [(page)]="rewardSchemesQuery.page"  
-                    [pageSize]="rewardSchemesQuery.limit"
-                    [collectionSize]="totalRewardSchemes" 
-                    [boundaryLinks]="true"
-                    (pageChange)="handlePageChange($event)" 
-                    [maxSize]="5">
-                </ngb-pagination>
-            </div>
-        </div>
-    </div>
+  <!-- Pagination Controls -->
+  <div class="pagination-row">
+    <span class="page-size-label">Rows per page</span>
+    <select [(ngModel)]="rewardSchemesQuery.limit" (change)="handleLimitChange()" class="form-select">
+      <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
+    </select>
+    <ngb-pagination
+      [(page)]="rewardSchemesQuery.page"
+      [pageSize]="rewardSchemesQuery.limit"
+      [collectionSize]="totalRewardSchemes"
+      [boundaryLinks]="true"
+      (pageChange)="handlePageChange($event)"
+      [maxSize]="5">
+    </ngb-pagination>
+  </div>
 </div>
 
   

--- a/src/app/services/api-request.service.ts
+++ b/src/app/services/api-request.service.ts
@@ -452,8 +452,24 @@ getFocusEntities(): Observable<any> {
     .pipe(map((res: any) => res));
 }
 
-      
-}   
+getFocusWarehouses(): Observable<any> {
+  return this.http
+    .get(this.ApiUrls.mainUrl + this.ApiUrls.getFocusWarehouses)
+    .pipe(map((res: any) => res));
+}
+
+getFocusBranches(): Observable<any> {
+  return this.http
+    .get(this.ApiUrls.mainUrl + this.ApiUrls.getFocusBranches)
+    .pipe(map((res: any) => res));
+}
+
+retryFocusSync(orderId: string): Observable<any> {
+  return this.http.post(this.ApiUrls.mainUrl + this.ApiUrls.retryFocusSync, { orderId })
+    .pipe(map((res: any) => res));
+}
+
+}
 
 
 

--- a/src/app/services/api-urls.service.ts
+++ b/src/app/services/api-urls.service.ts
@@ -119,10 +119,13 @@ deleteProductCatlog = 'productCatlog/delete/';
 // Focus Product / Unit APIs
 getFocusProducts = 'products/focus-products';
 getFocusEntities = 'products/focus-entities';
+getFocusWarehouses = 'products/focus-warehouses';
+getFocusBranches = 'products/focus-branches';
 
 //order
 checkoutUrl = 'order/create';
-getAllOrders = '/order/orders';
+getAllOrders = 'order/orders';
+retryFocusSync = 'order/retryFocusSync';
 
 // Credit Notes
 issueCreditNote      = 'creditNotes/issue';

--- a/src/app/transaction-ledger/transaction-ledger.component.html
+++ b/src/app/transaction-ledger/transaction-ledger.component.html
@@ -48,31 +48,19 @@
   </div>
 
   <!-- Pagination Controls -->
-  <div class="row">
-    <div class="col-sm-12 text-right">
-      <div class="d-flex justify-content-end align-items-center">
-
-        <!-- Page Size Selector -->
-        <select [(ngModel)]="limit" (change)="handleLimitChange()" 
-                class="form-select mx-2" 
-                style="width:100px; margin-bottom: 16px;">
-          <option *ngFor="let limitOption of limitOptions" [value]="limitOption">
-            {{ limitOption }}
-          </option>
-        </select>  
-
-        <!-- Pagination -->
-        <ngb-pagination
-          class="mx-2"
-          [(page)]="currentPage"
-          [pageSize]="limit"
-          [collectionSize]="totalTransactions"
-          [boundaryLinks]="true"
-          (pageChange)="handlePageChange($event)"
-          [maxSize]="5">
-        </ngb-pagination>
-
-      </div>
-    </div>
+  <div class="pagination-row">
+    <span class="page-size-label">Rows per page</span>
+    <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select">
+      <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
+    </select>
+    <ngb-pagination
+      [(page)]="currentPage"
+      [pageSize]="limit"
+      [collectionSize]="totalTransactions"
+      [boundaryLinks]="true"
+      (pageChange)="handlePageChange($event)"
+      [maxSize]="5">
+    </ngb-pagination>
   </div>
+
 </div>

--- a/src/app/transactions/transactions.component.html
+++ b/src/app/transactions/transactions.component.html
@@ -118,27 +118,20 @@
             </table>
         </div>
 
-        <div class="row">
-            <div class="col-sm-12 text-right">
-              <div class="d-flex justify-content-end">
-                <!-- Limit Dropdown -->
-                <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select mx-2" style="width:100px; margin-bottom: 16px">
-                  <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
-                </select>
-                
-                <!-- Pagination Controls -->
-                <ngb-pagination
-                  class="mx-2"
-                  [(page)]="currentPage"
-                  [pageSize]="limit"
-                  [collectionSize]="totalPages * limit" 
-                  [boundaryLinks]="true"
-                  (pageChange)="handlePageChange($event)"
-                  [maxSize]="5">
-                </ngb-pagination>
-              </div>
-            </div>
-          </div>
+        <div class="pagination-row">
+          <span class="page-size-label">Rows per page</span>
+          <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select">
+            <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
+          </select>
+          <ngb-pagination
+            [(page)]="currentPage"
+            [pageSize]="limit"
+            [collectionSize]="totalPages * limit"
+            [boundaryLinks]="true"
+            (pageChange)="handlePageChange($event)"
+            [maxSize]="5">
+          </ngb-pagination>
+        </div>
           
 <!-- Update Branch Modal -->
 <div class="modal" tabindex="-1" [ngClass]="{ 'show': showUpdateModal }" style="display: block; margin-top: 100px;"

--- a/src/app/unverified-users/unverified-users.component.html
+++ b/src/app/unverified-users/unverified-users.component.html
@@ -60,25 +60,19 @@
 </div>
 
 <!-- Pagination Controls -->
-<div class="row">
-  <div class="col-sm-12 text-right">
-    <div class="d-flex justify-content-end">
-      <!-- Page Size Selector -->
-      <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select mx-2" style="width:100px; margin-bottom: 16px">
-        <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
-      </select>
-
-      <!-- Pagination Controls -->
-      <ngb-pagination class="mx-2"
-                      [(page)]="currentPage"
-                      [pageSize]="limit"
-                      [collectionSize]="totalUsers"
-                      [boundaryLinks]="true"
-                      (pageChange)="handlePageChange($event)"
-                      [maxSize]="5">
-      </ngb-pagination>
-    </div>
-  </div>
+<div class="pagination-row">
+  <span class="page-size-label">Rows per page</span>
+  <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select">
+    <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
+  </select>
+  <ngb-pagination
+    [(page)]="currentPage"
+    [pageSize]="limit"
+    [collectionSize]="totalUsers"
+    [boundaryLinks]="true"
+    (pageChange)="handlePageChange($event)"
+    [maxSize]="5">
+  </ngb-pagination>
 </div>
 
 <!-- Modal for Editing unverified User -->

--- a/src/app/user-list/user-list.component.html
+++ b/src/app/user-list/user-list.component.html
@@ -104,24 +104,19 @@
         </div>
 
         <!-- Pagination Controls -->
-        <div class="row">
-            <div class="col-sm-12 text-right">
-                <div class="d-flex justify-content-end">
-                    <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select mx-2" style="width:100px; margin-bottom: 16px">
-                        <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
-                    </select>
-                    <ngb-pagination class="mx-2"
-                [(page)]="currentPage"
-                [pageSize]="limit"
-                [collectionSize]="total"   
-                [boundaryLinks]="true"
-                (pageChange)="handlePageChange($event)"
-                [maxSize]="5">
-</ngb-pagination>
-
-                    
-                </div>
-            </div>
+        <div class="pagination-row">
+          <span class="page-size-label">Rows per page</span>
+          <select [(ngModel)]="limit" (change)="handleLimitChange()" class="form-select">
+            <option *ngFor="let limitOption of limitOptions" [value]="limitOption">{{ limitOption }}</option>
+          </select>
+          <ngb-pagination
+            [(page)]="currentPage"
+            [pageSize]="limit"
+            [collectionSize]="total"
+            [boundaryLinks]="true"
+            (pageChange)="handlePageChange($event)"
+            [maxSize]="5">
+          </ngb-pagination>
         </div>
     </div>
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -62,18 +62,55 @@ body { margin: 0; background-color: #f6f9fa!important }
 /*    font-size: 14px;*/
 /*}*/
 
+/* ── Pagination ─────────────────────────────────────────── */
+.pagination-row {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+.pagination-row .page-size-label {
+    font-size: 0.8rem;
+    color: #6c757d;
+    white-space: nowrap;
+}
+.pagination-row .form-select {
+    width: 70px !important;
+    font-size: 0.82rem !important;
+    padding: 0.25rem 1.75rem 0.25rem 0.5rem !important;
+    height: 32px !important;
+    min-height: unset !important;
+    margin: 0 !important;
+    line-height: 1.4 !important;
+}
+.pagination-row ngb-pagination,
+.pagination-row .pagination {
+    margin: 0 !important;
+}
+.pagination-row .pagination {
+    gap: 2px;
+}
 .page-link {
+    font-size: 0.82rem;
+    padding: 0.3rem 0.6rem;
+    line-height: 1.4;
+    border-radius: 6px !important;
+    border: 1px solid #dee2e6;
     color: #2C3E50;
 }
-
 .active > .page-link, .page-link.active {
     background-color: #2C3E50;
     border-color: #2C3E50;
+    color: white;
 }
-
 .page-link:hover {
     background-color: #19232c;
     border-color: #19232c;
+    color: white;
+}
+.page-item.disabled .page-link {
+    color: #adb5bd;
 }
 
 .modal-body {


### PR DESCRIPTION
## Summary

- **Order List overhaul** — expandable rows show full item breakdown, price/GST breakdown, Focus Sync details, and a "Retry Sync" button for FAILED orders; status filter buttons (All / Pending / Confirmed / etc.) added to header
- **Product catalog checkout** — warehouse, branch, and narration fields added; required-field validation blocks submission until all three are selected; form resets on successful order
- **API services** — `getFocusWarehouses`, `getFocusBranches`, and `retryFocusSync` endpoints wired up in `api-request.service.ts` / `api-urls.service.ts`
- **Pagination consistency** — all list pages (batch, brand, credit notes, payouts, product data, product list, product offers, reward schemes, transaction ledger, transactions, unverified users, user list) migrated to shared `pagination-row` layout class

## Test plan

- [ ] Open Order List — verify status filter buttons show/hide rows correctly
- [ ] Click a row — verify expandable panel shows items, amounts, and Focus Sync info
- [ ] For an order with `focusSyncStatus = FAILED`, verify "Retry Sync" button appears and triggers the API call
- [ ] Open Product Catalog and add items to cart → proceed to checkout — verify warehouse, branch, and narration fields are present and form blocks submission when any required field is missing
- [ ] Complete a successful order — verify cart and form fields reset
- [ ] Spot-check pagination controls on at least 3 list pages for visual consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)