### PR TITLE
feat: product categories master — offer/dealer category tagging

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -25,6 +25,7 @@ import { CreateProductComponent } from './create-product/create-product.componen
 import { EditProductComponent } from './edit-product/edit-product.component';
 import { TransactionLedgerComponent } from './transaction-ledger/transaction-ledger.component';
 import { CreditNotesComponent } from './credit-notes/credit-notes.component';
+import { ProductCategoryListComponent } from './product-category-list/product-category-list.component';
 
 const ADMIN = ['SuperUser'];
 const STAFF = ['SuperUser', 'SalesExecutive'];
@@ -56,6 +57,7 @@ export const routes: Routes = [
             {path: 'edit-product', component: EditProductComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
             {path: 'transaction-ledger', component: TransactionLedgerComponent},
             {path: 'credit-notes', component: CreditNotesComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
+            {path: 'product-category-list', component: ProductCategoryListComponent, canActivate: [RoleGuard], data: { roles: ADMIN }},
         ]
 
     },

--- a/src/app/layout/layout.component.html
+++ b/src/app/layout/layout.component.html
@@ -146,6 +146,14 @@
                             <span *ngIf="!isSidebarCollapsed" style="border-left: 1px solid #ccc" class="px-2">Reward Schemes</span>
                         </div>
                     </li>
+
+                    <!--product-category-list-->
+                    <li class="nav-item" (click)="navigateTo('product-category-list')">
+                        <div style="display: flex; align-items: center;">
+                            <i class="bx px-2 bx-category" style="font-size: 20px;" title="Product Categories"></i>
+                            <span *ngIf="!isSidebarCollapsed" style="border-left: 1px solid #ccc" class="px-2">Product Categories</span>
+                        </div>
+                    </li>
                 </ul>
             </li>
         </ul>

--- a/src/app/product-category-list/product-category-list.component.html
+++ b/src/app/product-category-list/product-category-list.component.html
@@ -1,0 +1,66 @@
+<div class="container-fluid container-mt shadow-sm">
+  <div class="row mb-4">
+    <div class="col-sm-2"><h4>Product Categories</h4></div>
+    <div class="col-sm-10">
+      <div class="d-flex justify-content-end">
+        <button class="btn btn-primary" (click)="openAdd(categoryModal)">Add Category</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="table-wrapper">
+    <table class="table table-hover">
+      <thead>
+        <tr>
+          <th scope="col">S.NO</th>
+          <th scope="col">Category Name</th>
+          <th scope="col">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr *ngFor="let category of categories; let i = index">
+          <td>{{ i + 1 }}</td>
+          <td>{{ category.name }}</td>
+          <td>
+            <button (click)="openEdit(category, categoryModal)" class="btn btn-warning mx-2" title="Edit">
+              <i class="bx bx-edit"></i>
+            </button>
+            <button (click)="delete(category._id)" class="btn btn-danger mx-2" title="Delete">
+              <i class="bx bx-trash"></i>
+            </button>
+          </td>
+        </tr>
+        <tr *ngIf="categories.length === 0">
+          <td class="text-center" colspan="3">No Records found</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<ng-template #categoryModal let-modal>
+  <div class="modal-header">
+    <h4 class="modal-title">{{ currentCategory._id ? 'Edit' : 'Add' }} Product Category</h4>
+  </div>
+  <div class="modal-body">
+    <form #categoryForm="ngForm" novalidate class="modal-box shadow-sm">
+      <div class="form-group mb-3">
+        <label class="form-label" for="catName">Category Name <span class="text-danger">*</span></label>
+        <input type="text" class="form-control" id="catName" [(ngModel)]="currentCategory.name"
+               name="name" required #catName="ngModel" placeholder="Enter category name" />
+        <div *ngIf="catName.invalid && (catName.touched || submitted)" class="text-danger">
+          Category name is required.
+        </div>
+      </div>
+      <div *ngIf="errors.length > 0" class="alert alert-danger mt-2">
+        <ul class="mb-0">
+          <li *ngFor="let error of errors">{{ error }}</li>
+        </ul>
+      </div>
+    </form>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-secondary" (click)="modal.close()">Close</button>
+    <button type="button" class="btn btn-primary" (click)="save(modal)">Save</button>
+  </div>
+</ng-template>

--- a/src/app/product-category-list/product-category-list.component.ts
+++ b/src/app/product-category-list/product-category-list.component.ts
@@ -11,8 +11,7 @@ import { takeUntil } from 'rxjs';
   selector: 'app-product-category-list',
   standalone: true,
   imports: [FormsModule, CommonModule],
-  templateUrl: './product-category-list.component.html',
-  styleUrl: './product-category-list.component.css'
+  templateUrl: './product-category-list.component.html'
 })
 export class ProductCategoryListComponent extends Unsubscribable implements OnInit {
   @ViewChild('categoryForm') categoryForm!: NgForm;

--- a/src/app/product-category-list/product-category-list.component.ts
+++ b/src/app/product-category-list/product-category-list.component.ts
@@ -1,0 +1,126 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { ApiRequestService } from '../services/api-request.service';
+import { FormsModule, NgForm } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+import Swal from 'sweetalert2';
+import { Unsubscribable } from '../shared/unsubscribable';
+import { takeUntil } from 'rxjs';
+
+@Component({
+  selector: 'app-product-category-list',
+  standalone: true,
+  imports: [FormsModule, CommonModule],
+  templateUrl: './product-category-list.component.html',
+  styleUrl: './product-category-list.component.css'
+})
+export class ProductCategoryListComponent extends Unsubscribable implements OnInit {
+  @ViewChild('categoryForm') categoryForm!: NgForm;
+
+  categories: any[] = [];
+  currentCategory: any = { name: '', categoryId: '' };
+  submitted = false;
+  errors: string[] = [];
+
+  constructor(
+    private apiRequestService: ApiRequestService,
+    private modalService: NgbModal
+  ) { super(); }
+
+  ngOnInit(): void {
+    this.loadCategories();
+  }
+
+  loadCategories(): void {
+    this.apiRequestService.getProductCategories().pipe(takeUntil(this.destroy$)).subscribe({
+      next: (response: any) => {
+        this.categories = response.data || [];
+      },
+      error: () => {
+        this.showError('Error fetching product categories!');
+      }
+    });
+  }
+
+  openAdd(content: any): void {
+    this.currentCategory = { name: '', categoryId: '' };
+    this.submitted = false;
+    this.errors = [];
+    this.modalService.open(content, { size: 'md' });
+  }
+
+  openEdit(category: any, content: any): void {
+    this.currentCategory = { ...category };
+    this.submitted = false;
+    this.errors = [];
+    this.modalService.open(content, { size: 'md' });
+  }
+
+  save(modal: any): void {
+    this.submitted = true;
+    this.errors = [];
+
+    if (this.categoryForm.invalid) {
+      this.errors.push('Please fill in all required fields.');
+      return;
+    }
+
+    Swal.fire({
+      title: 'Are you sure?',
+      text: 'Do you want to save this product category?',
+      icon: 'question',
+      showCancelButton: true,
+      confirmButtonText: 'Yes, save it!',
+      cancelButtonText: 'No, cancel'
+    }).then((result) => {
+      if (result.isConfirmed) {
+        const request = this.currentCategory._id
+          ? this.apiRequestService.updateProductCategoryMaster(this.currentCategory._id, this.currentCategory)
+          : this.apiRequestService.createProductCategoryMaster(this.currentCategory);
+
+        request.pipe(takeUntil(this.destroy$)).subscribe({
+          next: () => {
+            this.loadCategories();
+            this.showSuccess(this.currentCategory._id ? 'Category updated successfully!' : 'Category added successfully!');
+            modal.close();
+          },
+          error: (error: any) => {
+            const msg = error?.error?.message || error?.message || 'Something went wrong while saving.';
+            this.errors.push(msg);
+          }
+        });
+      }
+    });
+  }
+
+  delete(id: string): void {
+    Swal.fire({
+      title: 'Are you sure?',
+      text: 'You won\'t be able to revert this!',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'Yes, delete it!',
+      cancelButtonText: 'No, keep it'
+    }).then((result) => {
+      if (result.isConfirmed) {
+        this.apiRequestService.deleteProductCategoryMaster(id).pipe(takeUntil(this.destroy$)).subscribe({
+          next: () => {
+            this.loadCategories();
+            Swal.fire('Deleted!', 'Product category has been deleted.', 'success');
+          },
+          error: () => {
+            this.showError('Error deleting product category!');
+          }
+        });
+      }
+    });
+  }
+
+  showSuccess(message: string): Promise<any> {
+    return Swal.fire({ icon: 'success', title: 'Success', text: message });
+  }
+
+  showError(message: string): Promise<any> {
+    return Swal.fire({ icon: 'error', title: 'Error', text: message });
+  }
+}

--- a/src/app/product-offers/product-offers.component.html
+++ b/src/app/product-offers/product-offers.component.html
@@ -123,20 +123,21 @@
                     </div>
                 </div>
 
-                <!-- Route Scheme -->
+                <!-- Product Category -->
                 <div class="row">
                     <div class="col-sm-12 mb-3 form-group">
-                        <label class="form-label" for="routeScheme">Route Scheme (Salesman)</label>
+                        <label class="form-label" for="productCategory">Product Category <span class="text-danger">*</span></label>
                         <ng-select
-                            [items]="salesExecutives"
+                            [items]="productCategories"
                             bindLabel="name"
-                            bindValue="mobile"
-                            [(ngModel)]="currentOffer.routeScheme"
-                            name="routeScheme"
-                            placeholder="All Dealers (no filter)"
-                            [multiple]="true"
-                            [clearable]="true"
+                            bindValue="_id"
+                            [(ngModel)]="currentOffer.productCategory"
+                            name="productCategory"
+                            placeholder="Select a category"
+                            [multiple]="false"
+                            [clearable]="false"
                             [searchable]="true"
+                            required
                         ></ng-select>
                     </div>
                 </div>

--- a/src/app/product-offers/product-offers.component.ts
+++ b/src/app/product-offers/product-offers.component.ts
@@ -28,7 +28,7 @@ import { takeUntil } from 'rxjs';
 export class ProductOffersComponent extends Unsubscribable implements OnInit {
   @ViewChild('productOfferForm') productOfferForm!: NgForm;
   productOffers: any[] = [];
-  salesExecutives: any[] = [];
+  productCategories: any[] = [];
   currentOffer: any = {
     productOfferImageUrl: '',
     productOfferDescription: '',
@@ -37,7 +37,7 @@ export class ProductOffersComponent extends Unsubscribable implements OnInit {
     cashback: 0,
     redeemPoints: 0,
     price: '',
-    routeScheme: []
+    productCategory: null
   };
 
   productOffersQuery: any = {
@@ -72,38 +72,20 @@ priceList: Array<{ selectedKey: string; price: number }> = [{ selectedKey: 'All'
   ngOnInit(): void {
     this.loadProductOffers();
     this.getAllStatesZonesAndDistricts();
-    this.loadSalesExecutives();
+    this.loadProductCategories();
   }
 
-  // Accepts a string (legacy) or string[] (current) and returns display names joined by ', '
-  getSeName(routeScheme: string | string[] | null): string {
-    if (!routeScheme) return '';
-    const mobiles = Array.isArray(routeScheme) ? routeScheme : [routeScheme];
-    return mobiles
-      .map(mobile => {
-        const se = this.salesExecutives.find(s => s.mobile === mobile);
-        return se ? se.name : mobile;
-      })
-      .join(', ');
-  }
-
-  /** @deprecated kept for call-site compatibility — use getSeName */
-  _getSeName(mobile: string): string {
-    const se = this.salesExecutives.find(s => s.mobile === mobile);
-    return se ? se.name : mobile;
-  }
-
-  // Normalises legacy string or new string[] into always-an-array for *ngFor
-  asArray(value: string | string[] | null | undefined): string[] {
-    if (!value) return [];
-    return Array.isArray(value) ? value : [value];
-  }
-
-  loadSalesExecutives() {
-    this.apiRequestService.getAllSalesExecutives().pipe(takeUntil(this.destroy$)).subscribe({
-      next: (response: any) => { this.salesExecutives = response.data || response; },
-      error: (err) => console.error('Error loading sales executives:', err)
+  loadProductCategories() {
+    this.apiRequestService.getProductCategories().pipe(takeUntil(this.destroy$)).subscribe({
+      next: (response: any) => { this.productCategories = response.data || []; },
+      error: (err) => console.error('Error loading product categories:', err)
     });
+  }
+
+  getCategoryName(categoryId: string | null): string {
+    if (!categoryId) return '';
+    const cat = this.productCategories.find(c => c._id === categoryId);
+    return cat ? cat.name : categoryId;
   }
 
   loadProductOffers() {
@@ -187,7 +169,7 @@ priceList: Array<{ selectedKey: string; price: number }> = [{ selectedKey: 'All'
         productOfferStatus: 'Active',
         cashback: 0,
         redeemPoints: 0,
-        routeScheme: []
+        productCategory: null
       };
   
       // Set default date
@@ -266,7 +248,9 @@ priceList: Array<{ selectedKey: string; price: number }> = [{ selectedKey: 'All'
       formData.append('cashback', this.currentOffer.cashback.toString());
       formData.append('redeemPoints', this.currentOffer.redeemPoints.toString());
       formData.append('price', JSON.stringify(this.currentOffer.price));
-      formData.append('routeScheme', JSON.stringify(this.currentOffer.routeScheme || []));
+      if (this.currentOffer.productCategory) {
+        formData.append('productCategory', this.currentOffer.productCategory);
+      }
 
       // Update or Create Offer
       if (this.currentOffer._id) {

--- a/src/app/services/api-request.service.ts
+++ b/src/app/services/api-request.service.ts
@@ -313,6 +313,31 @@ deleteProductCategory(id: string) {
     );
 }
 
+// Product Category Master APIs
+getProductCategories(): Observable<any> {
+    return this.http.get(this.ApiUrls.mainUrl + this.ApiUrls.getProductCategories).pipe(
+        map((res: any) => res)
+    );
+}
+
+createProductCategoryMaster(data: any): Observable<any> {
+    return this.http.post(this.ApiUrls.mainUrl + this.ApiUrls.createProductCategory, data).pipe(
+        map((res: any) => res)
+    );
+}
+
+updateProductCategoryMaster(id: string, data: any): Observable<any> {
+    return this.http.put(this.ApiUrls.mainUrl + this.ApiUrls.updateProductCategory + id, data).pipe(
+        map((res: any) => res)
+    );
+}
+
+deleteProductCategoryMaster(id: string): Observable<any> {
+    return this.http.delete(this.ApiUrls.mainUrl + this.ApiUrls.deleteProductCategory + id).pipe(
+        map((res: any) => res)
+    );
+}
+
 // Create a new order
 createOrder(data: any): Observable<any> {
     return this.http.post(this.ApiUrls.mainUrl + this.ApiUrls.checkoutUrl, data).pipe(

--- a/src/app/services/api-urls.service.ts
+++ b/src/app/services/api-urls.service.ts
@@ -116,6 +116,12 @@ searchProductCatlog = 'productCatlog/search';
 updateProductCatlog = 'productCatlog/update/'; 
 deleteProductCatlog = 'productCatlog/delete/'; 
 
+// Product Category API URLs
+createProductCategory = 'productCategories';
+getProductCategories = 'productCategories/all';
+updateProductCategory = 'productCategories/';
+deleteProductCategory = 'productCategories/';
+
 // Focus Product / Unit APIs
 getFocusProducts = 'products/focus-products';
 getFocusEntities = 'products/focus-entities';

--- a/src/app/user-list/user-list.component.html
+++ b/src/app/user-list/user-list.component.html
@@ -258,13 +258,30 @@
         </div>
               
             
+            <!-- Product Categories (Dealer - required, others - optional) -->
+            <div class="row" *ngIf="currentUser.accountType === 'Dealer'">
+                <div class="col-sm-12 mb-3 form-group">
+                    <label class="form-label">Product Categories <span class="text-danger">*</span></label>
+                    <ng-select
+                        [items]="productCategories"
+                        bindLabel="name"
+                        bindValue="_id"
+                        [(ngModel)]="currentUser.productCategories"
+                        name="addProductCategories"
+                        [multiple]="true"
+                        [clearable]="true"
+                        [searchable]="true"
+                        placeholder="Select product categories"
+                    ></ng-select>
+                </div>
+            </div>
+
             <!-- Address in One Row (if Dealer) -->
             <div class="row" *ngIf="currentUser.accountType === 'Dealer'">
                 <div class="col-sm-12 mb-3 form-group">
-                    <label for="addAddress">Address</label> <!-- Removed the '*' for Address -->
+                    <label for="addAddress">Address</label>
                     <textarea class="form-control" id="addAddress" [(ngModel)]="currentUser.address" name="addAddress" rows="3"
                               placeholder="Enter address" #address="ngModel"></textarea>
-                    <!-- Removed error message for Address -->
                 </div>
             </div>
 
@@ -420,6 +437,24 @@
 </div>
 
             
+            <!-- Product Categories (Dealer - required, others - optional) -->
+            <div class="row" *ngIf="currentUser.accountType === 'Dealer'">
+                <div class="col-sm-12 mb-3 form-group">
+                    <label class="form-label">Product Categories <span class="text-danger">*</span></label>
+                    <ng-select
+                        [items]="productCategories"
+                        bindLabel="name"
+                        bindValue="_id"
+                        [(ngModel)]="currentUser.productCategories"
+                        name="editProductCategories"
+                        [multiple]="true"
+                        [clearable]="true"
+                        [searchable]="true"
+                        placeholder="Select product categories"
+                    ></ng-select>
+                </div>
+            </div>
+
             <!-- Address in One Row (if Dealer) -->
             <div class="row" *ngIf="currentUser.accountType === 'Dealer'">
                 <div class="col-sm-12 mb-3 form-group">

--- a/src/app/user-list/user-list.component.ts
+++ b/src/app/user-list/user-list.component.ts
@@ -11,11 +11,12 @@ import {AuthService} from "../services/auth.service";
 import { UnverifiedUsersComponent } from '../unverified-users/unverified-users.component';
 import { Unsubscribable } from '../shared/unsubscribable';
 import { takeUntil } from 'rxjs';
+import { NgSelectModule } from '@ng-select/ng-select';
 
 @Component({
     selector: 'app-user-list',
     standalone: true,
-    imports: [CommonModule, FormsModule, NgbPagination,RouterModule, UnverifiedUsersComponent],
+    imports: [CommonModule, FormsModule, NgbPagination, RouterModule, UnverifiedUsersComponent, NgSelectModule],
     templateUrl: './user-list.component.html',
     styleUrls: ['./user-list.component.css']
 })
@@ -62,12 +63,13 @@ export class UserListComponent extends Unsubscribable implements OnInit {
         {id: 'SuperUser', name: 'Super User'},
         {id:'SalesExecutive', name:'SalesExecutive'}
     ];
-    errorsAddUser: string[] = [];  
-    errorsEditUser: string[] = []; 
-    currentTab: string = 'users'; 
+    errorsAddUser: string[] = [];
+    errorsEditUser: string[] = [];
+    currentTab: string = 'users';
     stateNames: any[] = [];
     zoneNames: any[] = [];
     districtNames: any[] = [];
+    productCategories: any[] = [];
 
     constructor(private apiService: ApiRequestService, private modalService: NgbModal,
                 private router: Router, private apiUrls: ApiUrlsService, private AuthService: AuthService) {
@@ -81,6 +83,14 @@ export class UserListComponent extends Unsubscribable implements OnInit {
         this.getStateNames();
         this.getZoneNames();
         this.getDistrictNames();
+        this.loadProductCategories();
+    }
+
+    loadProductCategories(): void {
+        this.apiService.getProductCategories().pipe(takeUntil(this.destroy$)).subscribe({
+            next: (response: any) => { this.productCategories = response.data || []; },
+            error: (err) => console.error('Error loading product categories:', err)
+        });
     }
 
     loadUsers(): void {
@@ -229,7 +239,7 @@ exportUsers(): void {
 
     addUser(userModal: any): void {
         // Reset the currentUser object to a fresh
-        this.currentUser = { name: '', mobile: '', password: '', accountType: 'Painter' , salesExecutive: '', state: '', zone : '', district: ''};
+        this.currentUser = { name: '', mobile: '', password: '', accountType: 'Painter', salesExecutive: '', state: '', zone: '', district: '', productCategories: [] };
     
         // Clear any previous errors and submitted flag
         this.errorsAddUser = [];
@@ -247,16 +257,16 @@ exportUsers(): void {
 
     submitForm(modal: any): void {
         this.submitted = true;
-    
+        this.errorsAddUser = [];
+
+        if (this.currentUser.accountType === 'Dealer' &&
+            (!this.currentUser.productCategories || this.currentUser.productCategories.length === 0)) {
+            this.errorsAddUser = ['Product Categories are required for Dealer accounts.'];
+            return;
+        }
+
         if (this.userForm.valid) {
-            if (
-                this.currentUser.accountType === 'Dealer' &&
-                (!this.currentUser.state || !this.currentUser.zone || !this.currentUser.district)
-            ) {
-                this.confirmSave(modal);
-            } else {
-                this.confirmSave(modal);
-            }
+            this.confirmSave(modal);
         }
     }
 
@@ -294,16 +304,16 @@ exportUsers(): void {
     
     updateUser(modal: any, userForm: any): void {
         this.submitted = true;
-        
+        this.errorsEditUser = [];
+
+        if (this.currentUser.accountType === 'Dealer' &&
+            (!this.currentUser.productCategories || this.currentUser.productCategories.length === 0)) {
+            this.errorsEditUser = ['Product Categories are required for Dealer accounts.'];
+            return;
+        }
+
         if (userForm.valid) {
-            if (
-                this.currentUser.accountType === 'Dealer' &&
-                (!this.currentUser.state || !this.currentUser.zone || !this.currentUser.district)
-            ) {
-                this.confirmUpdate(modal);
-            } else {
-                this.confirmUpdate(modal);
-            }
+            this.confirmUpdate(modal);
         }
     }
     


### PR DESCRIPTION
Replaces routeScheme (SE-mobile) selection on product offers with a Product Categories master, wired to dealer tagging and offer filtering:

- New product-category-list component (standalone): full CRUD table with add/edit modal for category name; Admin-only actions
- api-urls.service: added createProductCategory, getProductCategories, updateProductCategory, deleteProductCategory URL constants
- api-request.service: added *Master() category methods (named to avoid collision with existing product-catalog deleteProductCategory)
- app.routes.ts: added product-category-list route (RoleGuard, ADMIN)
- layout.component.html: added "Product Categories" item to Masters submenu
- product-offers component: replaced routeScheme multi-select with a single ng-select bound to productCategory (_id); replaced loadSalesExecutives with loadProductCategories; added getCategoryName() helper
- user-list component: added NgSelectModule, product-categories multi-select in Add/Edit dealer modals (bindValue="_id", multiple); manual validation enforces at least one category for Dealer accountType (Angular [required] on ng-select does not integrate with template-driven form validation)