### PR TITLE
feat(orders): server-side status + dealer filters in OrderListComponent

### DIFF
--- a/src/app/order-list/order-list.component.html
+++ b/src/app/order-list/order-list.component.html
@@ -1,15 +1,37 @@
 <div class="container-fluid container-mt shadow-sm">
 
   <!-- Header + filters -->
-  <div class="d-flex flex-wrap align-items-center gap-2 mb-3">
+  <div class="d-flex flex-wrap align-items-end gap-3 mb-3">
     <h5 class="mb-0 me-auto">Orders</h5>
-    <button class="btn btn-sm filter-btn"
-            [class.active]="statusFilter === ''"
-            (click)="setStatusFilter('')">All</button>
-    <button *ngFor="let s of statusOptions"
-            class="btn btn-sm filter-btn"
-            [class.active]="statusFilter === s"
-            (click)="setStatusFilter(s)">{{ s }}</button>
+
+    <div>
+      <label class="form-label small mb-1">Status</label>
+      <select class="form-select form-select-sm"
+              [(ngModel)]="statusFilter"
+              (change)="onStatusChange()">
+        <option value="">All</option>
+        <option *ngFor="let s of statusOptions" [value]="s">{{ s }}</option>
+      </select>
+    </div>
+
+    <div style="min-width: 240px;">
+      <label class="form-label small mb-1">Dealer</label>
+      <input type="text"
+             class="form-control form-control-sm"
+             placeholder="Search dealer code or name"
+             [(ngModel)]="dealerInput"
+             (ngModelChange)="onDealerInputChange($event)"
+             [ngbTypeahead]="dealerSearch"
+             [resultFormatter]="dealerFormatter"
+             [inputFormatter]="dealerFormatter"
+             (selectItem)="onDealerSelect($event)" />
+      <small *ngIf="dealersError" class="text-muted d-block mt-1">{{ dealersError }}</small>
+    </div>
+
+    <button *ngIf="hasActiveFilters()"
+            class="btn btn-sm btn-link p-0 align-self-end"
+            type="button"
+            (click)="clearFilters()">Clear filters</button>
   </div>
 
   <!-- Loading -->
@@ -33,7 +55,7 @@
         </tr>
       </thead>
       <tbody>
-        <ng-container *ngFor="let order of filteredOrders; let i = index">
+        <ng-container *ngFor="let order of orders; let i = index">
 
           <!-- Summary row -->
           <tr class="summary-row" (click)="toggleExpand(order.orderId)">
@@ -177,7 +199,7 @@
 
         </ng-container>
 
-        <tr *ngIf="filteredOrders.length === 0">
+        <tr *ngIf="orders.length === 0">
           <td colspan="8" class="text-center text-muted py-4">No orders found</td>
         </tr>
       </tbody>

--- a/src/app/order-list/order-list.component.spec.ts
+++ b/src/app/order-list/order-list.component.spec.ts
@@ -1,23 +1,82 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { of } from 'rxjs';
 
 import { OrderListComponent } from './order-list.component';
+import { ApiRequestService } from '../services/api-request.service';
 
 describe('OrderListComponent', () => {
   let component: OrderListComponent;
   let fixture: ComponentFixture<OrderListComponent>;
+  let apiSpy: jasmine.SpyObj<ApiRequestService>;
 
   beforeEach(async () => {
+    apiSpy = jasmine.createSpyObj<ApiRequestService>('ApiRequestService', [
+      'getAllOrders',
+      'getOrderDealers',
+      'retryFocusSync',
+    ]);
+    apiSpy.getAllOrders.and.returnValue(of({ orders: [], total: 0 }));
+    apiSpy.getOrderDealers.and.returnValue(of([
+      { _id: 'x', dealerCode: 'D0001', name: 'A' },
+    ]));
+
     await TestBed.configureTestingModule({
-      imports: [OrderListComponent]
-    })
-    .compileComponents();
+      imports: [OrderListComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ApiRequestService, useValue: apiSpy },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(OrderListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('passes status filter through to the service and resets to page 1', () => {
+    component.currentPage = 4;
+    component.statusFilter = 'PENDING';
+    component.onStatusChange();
+    expect(component.currentPage).toBe(1);
+    expect(apiSpy.getAllOrders).toHaveBeenCalledWith(
+      1, component.limit, jasmine.objectContaining({ status: 'PENDING' })
+    );
+  });
+
+  it('passes dealer code through to the service when a dealer is selected', () => {
+    component.onDealerSelect({ item: { _id: 'x', dealerCode: 'D0001', name: 'A' } } as any);
+    expect(component.dealerCodeFilter).toBe('D0001');
+    expect(apiSpy.getAllOrders).toHaveBeenCalledWith(
+      1, component.limit, jasmine.objectContaining({ dealerCode: 'D0001' })
+    );
+  });
+
+  it('clearFilters resets both filters and reloads', () => {
+    component.statusFilter = 'PENDING';
+    component.dealerCodeFilter = 'D0001';
+    apiSpy.getAllOrders.calls.reset();
+    component.clearFilters();
+    expect(component.statusFilter).toBe('');
+    expect(component.dealerCodeFilter).toBe('');
+    expect(apiSpy.getAllOrders).toHaveBeenCalledWith(
+      1, component.limit, { status: undefined, dealerCode: undefined }
+    );
+  });
+
+  it('clears dealer filter when the input is edited away from the selection', () => {
+    // Select a dealer first.
+    component.onDealerSelect({ item: { _id: 'x', dealerCode: 'D0001', name: 'A' } } as any);
+    apiSpy.getAllOrders.calls.reset();
+
+    // Simulate the user editing the input text.
+    component.onDealerInputChange('D000');
+
+    expect(component.dealerCodeFilter).toBe('');
+    expect(apiSpy.getAllOrders).toHaveBeenCalledWith(
+      1, component.limit, jasmine.objectContaining({ dealerCode: undefined })
+    );
   });
 });

--- a/src/app/order-list/order-list.component.ts
+++ b/src/app/order-list/order-list.component.ts
@@ -2,16 +2,23 @@ import { Component, OnInit } from '@angular/core';
 import { ApiRequestService } from '../services/api-request.service';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { NgbPagination } from '@ng-bootstrap/ng-bootstrap';
+import { NgbPagination, NgbTypeaheadModule } from '@ng-bootstrap/ng-bootstrap';
 import { Unsubscribable } from '../shared/unsubscribable';
-import { takeUntil } from 'rxjs';
+import { Observable, takeUntil } from 'rxjs';
+import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
+
+interface DealerOption {
+  _id: string;
+  dealerCode: string;
+  name: string;
+}
 
 @Component({
   selector: 'app-order-list',
   standalone: true,
-  imports: [CommonModule, FormsModule, NgbPagination],
+  imports: [CommonModule, FormsModule, NgbPagination, NgbTypeaheadModule],
   templateUrl: './order-list.component.html',
-  styleUrl: './order-list.component.css'
+  styleUrl: './order-list.component.css',
 })
 export class OrderListComponent extends Unsubscribable implements OnInit {
   orders: any[] = [];
@@ -21,19 +28,43 @@ export class OrderListComponent extends Unsubscribable implements OnInit {
   limitOptions = [5, 10, 20, 50];
   isLoading = false;
   expandedOrderId: string | null = null;
+
   statusFilter = '';
+  dealerCodeFilter = '';
+  dealerInput = '';
+  dealers: DealerOption[] = [];
+  dealersError = '';
+
   isRetrying: { [key: string]: boolean } = {};
   retryMessage: { [key: string]: string } = {};
 
   readonly statusOptions = ['PENDING', 'VERIFIED', 'REJECTED', 'DISPATCHED', 'IN-PARCEL'];
 
-  constructor(private apiRequestService: ApiRequestService) { super(); }
+  constructor(private apiRequestService: ApiRequestService) {
+    super();
+  }
 
-  ngOnInit(): void { this.loadOrders(); }
+  ngOnInit(): void {
+    this.loadDealers();
+    this.loadOrders();
+  }
+
+  loadDealers(): void {
+    this.apiRequestService.getOrderDealers()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (dealers) => { this.dealers = dealers; },
+        error: () => { this.dealersError = 'Could not load dealer list'; },
+      });
+  }
 
   loadOrders(): void {
     this.isLoading = true;
-    this.apiRequestService.getAllOrders(this.currentPage, this.limit)
+    const filters = {
+      status: this.statusFilter || undefined,
+      dealerCode: this.dealerCodeFilter || undefined,
+    };
+    this.apiRequestService.getAllOrders(this.currentPage, this.limit, filters)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (response) => {
@@ -41,13 +72,8 @@ export class OrderListComponent extends Unsubscribable implements OnInit {
           this.totalOrders = response.total;
           this.isLoading = false;
         },
-        error: () => { this.isLoading = false; }
+        error: () => { this.isLoading = false; },
       });
-  }
-
-  get filteredOrders(): any[] {
-    if (!this.statusFilter) return this.orders;
-    return this.orders.filter(o => o.status === this.statusFilter);
   }
 
   toggleExpand(orderId: string): void {
@@ -89,7 +115,7 @@ export class OrderListComponent extends Unsubscribable implements OnInit {
         error: (err: any) => {
           this.retryMessage[order.orderId] = err?.error?.message || 'Retry failed';
           this.isRetrying[order.orderId] = false;
-        }
+        },
       });
   }
 
@@ -97,9 +123,68 @@ export class OrderListComponent extends Unsubscribable implements OnInit {
     return (item.productPrice || 0) * (item.quantity || 0);
   }
 
-  setStatusFilter(s: string): void {
-    this.statusFilter = s;
+  onStatusChange(): void {
+    this.currentPage = 1;
     this.expandedOrderId = null;
+    this.loadOrders();
+  }
+
+  // ng-bootstrap typeahead source
+  dealerSearch = (text$: Observable<string>) =>
+    text$.pipe(
+      debounceTime(150),
+      distinctUntilChanged(),
+      map((term) => {
+        const t = (term || '').trim().toLowerCase();
+        const list = !t ? this.dealers : this.dealers.filter(
+          (d) =>
+            d.dealerCode.toLowerCase().includes(t) ||
+            (d.name || '').toLowerCase().includes(t)
+        );
+        return list.slice(0, 10);
+      })
+    );
+
+  dealerFormatter = (d: DealerOption) => `${d.dealerCode} — ${d.name}`;
+
+  onDealerSelect(event: any): void {
+    const d = event.item as DealerOption;
+    this.dealerCodeFilter = d.dealerCode;
+    this.dealerInput = this.dealerFormatter(d);
+    this.currentPage = 1;
+    this.expandedOrderId = null;
+    this.loadOrders();
+  }
+
+  onDealerInputChange(value: string): void {
+    // Keep `dealerCodeFilter` in sync with the visible input. If the user edits
+    // the text away from the formatted selection (or clears it), drop the filter.
+    const matchesSelection =
+      !!this.dealerCodeFilter &&
+      value === this.dealers
+        .filter((d) => d.dealerCode === this.dealerCodeFilter)
+        .map(this.dealerFormatter)[0];
+
+    if (!matchesSelection && this.dealerCodeFilter) {
+      this.dealerCodeFilter = '';
+      this.currentPage = 1;
+      this.expandedOrderId = null;
+      this.loadOrders();
+    }
+  }
+
+  clearFilters(): void {
+    if (!this.statusFilter && !this.dealerCodeFilter) return;
+    this.statusFilter = '';
+    this.dealerCodeFilter = '';
+    this.dealerInput = '';
+    this.currentPage = 1;
+    this.expandedOrderId = null;
+    this.loadOrders();
+  }
+
+  hasActiveFilters(): boolean {
+    return !!this.statusFilter || !!this.dealerCodeFilter;
   }
 
   handlePageChange(page: number): void {

--- a/src/app/services/api-request.service.ts
+++ b/src/app/services/api-request.service.ts
@@ -348,13 +348,25 @@ createOrder(data: any): Observable<any> {
   }
 
 
-  getAllOrders(page: number, limit: number) {
-    return this.http.post(this.ApiUrls.mainUrl + this.ApiUrls.getAllOrders, {
-      page,
-      limit
-    }).pipe(
-      map((res: any) => res)
-    );
+  getAllOrders(
+    page: number,
+    limit: number,
+    filters?: { status?: string; dealerCode?: string }
+  ) {
+    const body: any = { page, limit };
+    if (filters?.status) body.status = filters.status;
+    if (filters?.dealerCode) body.dealerCode = filters.dealerCode;
+    return this.http
+      .post(this.ApiUrls.mainUrl + this.ApiUrls.getAllOrders, body)
+      .pipe(map((res: any) => res));
+  }
+
+  getOrderDealers() {
+    return this.http
+      .get<{ success: boolean; dealers: { _id: string; dealerCode: string; name: string }[] }>(
+        this.ApiUrls.mainUrl + this.ApiUrls.getOrderDealersUrl
+      )
+      .pipe(map((res) => res.dealers || []));
   }
 
   exportTransaction(): Observable<Blob> {

--- a/src/app/services/api-urls.service.ts
+++ b/src/app/services/api-urls.service.ts
@@ -131,6 +131,7 @@ getFocusBranches = 'products/focus-branches';
 //order
 checkoutUrl = 'order/create';
 getAllOrders = 'order/orders';
+getOrderDealersUrl = 'order/dealers';
 retryFocusSync = 'order/retryFocusSync';
 
 // Credit Notes


### PR DESCRIPTION
## Summary
- Replaces the chip-style status filter (which only filtered the visible page) with server-driven filters: a status `<select>` and an `ngbTypeahead` dealer search.
- Wires the new backend endpoints (`POST /order/orders` filters, `GET /order/dealers`) through `ApiRequestService`.
- Filter changes reset to page 1; pagination keeps active filters; "Clear filters" resets both.
- Includes a divergence guard so editing the dealer input after a selection clears the stale filter.

## Depends on
- Backend: RunMyBus/aultra-paints-backend#153 — must merge first.

## Test plan
- [x] `ng build --configuration development` succeeds.
- [x] New component spec covers status filter, dealer selection, clear filters, and dealer-input divergence (4 tests).
- [ ] Karma cannot run locally — pre-existing broken specs in `guards/*.spec.ts`, `interceptor/token.interceptor.spec.ts`, and a missing `azure-blue.css` reference (commit `6cc9a3a`). Not introduced by this PR; please run the new tests via CI or a dev environment with Chrome.
- [ ] QA smoke as SuperUser: status select narrows the list; dealer typeahead filters by dealer; pagination keeps filters; Clear filters resets both; editing the dealer text after a selection clears the active filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)