### PR TITLE
feat(theme): colour action buttons across admin screens

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,6 +18,12 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
+        // Coloured ghosts for action clusters (edit pencil / delete trash on
+        // cards + table rows). Subtle tint at rest, brighter on hover.
+        editIcon:
+          "text-blue-600 hover:bg-blue-100 hover:text-blue-700",
+        destructiveIcon:
+          "text-red-600 hover:bg-red-100 hover:text-red-700",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/src/features/deals/deals.tsx
+++ b/src/features/deals/deals.tsx
@@ -171,7 +171,7 @@ export function Deals() {
                   >
                     <Button
                       size="icon"
-                      variant="ghost"
+                      variant="editIcon"
                       className="h-7 w-7"
                       onClick={() => setEditing(d)}
                       aria-label="Edit deal"
@@ -180,7 +180,7 @@ export function Deals() {
                     </Button>
                     <Button
                       size="icon"
-                      variant="ghost"
+                      variant="destructiveIcon"
                       className="h-7 w-7"
                       onClick={() => setDeleting(d)}
                       aria-label="Delete deal"

--- a/src/features/product-offers/product-offers.tsx
+++ b/src/features/product-offers/product-offers.tsx
@@ -175,7 +175,7 @@ export function ProductOffers() {
                   >
                     <Button
                       size="icon"
-                      variant="ghost"
+                      variant="editIcon"
                       className="h-7 w-7"
                       onClick={() => setEditing(o)}
                       aria-label="Edit offer"
@@ -184,7 +184,7 @@ export function ProductOffers() {
                     </Button>
                     <Button
                       size="icon"
-                      variant="ghost"
+                      variant="destructiveIcon"
                       className="h-7 w-7"
                       onClick={() => setDeleting(o)}
                       aria-label="Delete offer"

--- a/src/features/products/catalog-form.tsx
+++ b/src/features/products/catalog-form.tsx
@@ -434,7 +434,7 @@ export function CatalogForm({ initial }: CatalogFormProps) {
                           <Button
                             type="button"
                             size="sm"
-                            variant="ghost"
+                            variant="destructiveIcon"
                             disabled={rows.fields.length <= 1}
                             onClick={() => rows.remove(idx)}
                             aria-label="Delete row"

--- a/src/features/products/product-catlog.tsx
+++ b/src/features/products/product-catlog.tsx
@@ -189,7 +189,7 @@ export function ProductCatalog() {
                       <Button
                         asChild
                         size="icon"
-                        variant="ghost"
+                        variant="editIcon"
                         className="h-7 w-7"
                         aria-label="Edit product"
                       >
@@ -199,7 +199,7 @@ export function ProductCatalog() {
                       </Button>
                       <Button
                         size="icon"
-                        variant="ghost"
+                        variant="destructiveIcon"
                         className="h-7 w-7"
                         onClick={() => setDeleting(item)}
                         aria-label="Delete product"

--- a/src/features/reward-schemes/reward-schemes.tsx
+++ b/src/features/reward-schemes/reward-schemes.tsx
@@ -103,7 +103,7 @@ export function RewardSchemes() {
                 <div className="absolute right-2 top-2 flex items-center gap-1 rounded-md bg-background/90 p-1 shadow-sm">
                   <Button
                     size="icon"
-                    variant="ghost"
+                    variant="editIcon"
                     className="h-7 w-7"
                     onClick={() => setEditing(s)}
                     aria-label="Edit scheme"
@@ -112,7 +112,7 @@ export function RewardSchemes() {
                   </Button>
                   <Button
                     size="icon"
-                    variant="ghost"
+                    variant="destructiveIcon"
                     className="h-7 w-7"
                     onClick={() => onDelete(s)}
                     aria-label="Delete scheme"

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,7 @@
     --card-foreground: 222 47% 11%;
     --popover: 0 0% 100%;
     --popover-foreground: 222 47% 11%;
-    --primary: 212 36% 24%;             /* #2C3E50 */
+    --primary: 221 83% 53%;             /* #2563eb (blue-600) — brand action color */
     --primary-foreground: 0 0% 100%;
     --secondary: 210 40% 96%;
     --secondary-foreground: 222 47% 11%;
@@ -22,12 +22,12 @@
     --destructive-foreground: 0 0% 100%;
     --border: 214 32% 91%;
     --input: 214 32% 91%;
-    --ring: 212 36% 24%;
+    --ring: 221 83% 53%;                /* matches --primary so focus rings stay on-brand */
     --radius: 0.5rem;
     --sidebar: 210 7% 33%;              /* #495057 */
     --sidebar-foreground: 0 0% 100%;
     --sidebar-hover: 210 23% 14%;       /* #19232c */
-    --sidebar-accent: 212 36% 24%;      /* #2C3E50 — same as primary */
+    --sidebar-accent: 212 36% 24%;      /* #2C3E50 — sidebar stays slate, separate from --primary */
   }
 
   * {


### PR DESCRIPTION
## Summary
Add colour to action buttons across the admin portal:

- **Primary buttons** (New, Save, Submit, etc.) — slate `#2C3E50` → brand blue `#2563eb` (`blue-600`). Affects every `<Button>` using the default variant + focus rings everywhere. Sidebar tokens stay slate so the dark nav still anchors the layout.
- **Action-cluster icon buttons** — two new `Button` variants:
  - `editIcon` (blue ghost) for the pencil
  - `destructiveIcon` (red ghost) for the trash
- Applied to the 5 card-grid screens that have the edit/delete overlay (Deals, Product Offers, Product Catalog, Reward Schemes) and the Delete-row icon inside `catalog-form.tsx`.

The existing `destructive` variant (filled red AlertDialog Delete button) is unchanged — confirm dialogs still show their red call-to-action.

## Files changed
- `src/index.css` — `--primary` + `--ring` HSL values
- `src/components/ui/button.tsx` — `editIcon` and `destructiveIcon` variants
- `src/features/deals/deals.tsx`
- `src/features/product-offers/product-offers.tsx`
- `src/features/products/product-catlog.tsx`
- `src/features/reward-schemes/reward-schemes.tsx`
- `src/features/products/catalog-form.tsx`

## Test plan
- [x] `npm run typecheck` — zero errors
- [x] `npm run lint` — zero issues
- [x] `npm run build` — succeeds (2.65s)
- [ ] Sidebar still looks slate; active sidebar item still uses the old slate accent
- [ ] Primary buttons (`New deal`, `Save`, OTP submit, etc.) render in blue
- [ ] Cancel button stays outline / unchanged
- [ ] Edit pencil icons render blue, hover deepens to blue-700 with light-blue bg
- [ ] Delete trash icons render red, hover deepens to red-700 with light-red bg
- [ ] Confirm dialog Delete button (filled red) unchanged
- [ ] Focus rings (tab-key navigation) now use brand blue

## Dependency
Branched from `feat/deals-feature` (PR #103) because it colours the Deals icons too. Merge after #103 lands, or cherry-pick the non-Deals call sites if #103 is delayed.

Generated with [Claude Code](https://claude.com/claude-code)
